### PR TITLE
Update of FFV1 specification, Header part

### DIFF
--- a/ffv1.lyx
+++ b/ffv1.lyx
@@ -4160,33 +4160,390 @@ u(32)
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-slice_coding_mode 0: normal RC or VLC
+slice_coding_mode indicates the slice coding mode.
 \begin_inset Newline newline
 \end_inset
 
-1: store slice samples as raw PCM instead of context adaptive range coding
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="4" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+slice coding mode
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+normal Range Coding or VLC
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+raw PCM
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-slice_size Size of the slice in bytes, this allows finding the start of
- slices before previous slices have been fully decoded.
+slice_size indicates the size of the slice in bytes.
+\begin_inset Newline newline
+\end_inset
+
+Note: this allows finding the start of slices before previous slices have
+ been fully decoded.
  And allows this way parallel decoding as well as error resilience.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-error_status 0(no error), 1(slice contained a correctable error), 2(slice
- contains a uncorrectable error)
+error_status specifies the error status.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="5" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+error status
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+no error
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+slice contains a correctable error
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+2
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+slice contains a uncorrectable error
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-plane_count prior to version 4: without transparency: 2 else 3.
+plane_count indicates the count of planes and the associated plane types.
 \begin_inset Newline newline
 \end_inset
 
-version 4 and later: gray: 1, gray+alpha or color:2, color+alpha:3
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="7" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+plane types
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+forbidden
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+if version <4: forbidden; else gray
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+2
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+if version <4: forbidden; else gray+alpha
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+3
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+luma+chroma
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+4
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+luma+chroma+alpha
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Subsection
@@ -6016,58 +6373,585 @@ u(32)
 \end_layout
 
 \begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\labelwidthstring 00.00.0000
 \noindent
-version 0, 1 or 3.
- Version 2 was never enabled in the encoder thus version 2 files should
+version specifies the version of the bitstream.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="6" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+version
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+FFV1 version 0
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+FFV1 version 1
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+2
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved*
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+3
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+FFV1 version 3
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
+\begin_inset Newline newline
+\end_inset
+
+* Version 2 was never enabled in the encoder thus version 2 files should
  not exist, and this document does not describe them to keep the text simpler.
- 
 \end_layout
 
 \begin_layout Labeling
-\labelwidthstring 12345678901234567890
-micro_version For version 3, micro_version is 4, micro versions prior to
- this represent pre standard variants that should not exist in the wild.
- Decoders must not reject a file due to an unknown micro_version.
+\labelwidthstring 00.00.0000
+micro_version specifies the micro version of the bitstream, each new micro
+ version is compatible with the previous version.
+\begin_inset Newline newline
+\end_inset
+
+Decoders must not reject a file due to an unknown micro_version.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="4" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+micro_version
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0...3
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved*
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+4
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+first stable variant
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
+\begin_inset Newline newline
+\end_inset
+
+* were development versions which may be incompatible with the stable variants.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-coder_type Coder used, 0 (Golomb Rice), 1 (Range coder), 2 (Range coder
- with custom state transition table) 
+coder_type specifies the coder used
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="5" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+coder used
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Golomb Rice
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Range Coder with default state transition table
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+2
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Range Coder with custom state transition table
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-state_transition_delta The range coder custom state transition table.
- If it is not coded, all its elements are assumed to be 0.
+state_transition_delta specifiies the range coder custom state transition
+ table.
+\begin_inset Newline newline
+\end_inset
+
+If state_transition_delta is not present in the bitstream, all range coder
+ custom state transition table elements are assumed to be 0.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-colorspace_type 0 (YCbCr), 1 (JPEG2000_RCT)
+colorspace_type specifies the color space.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="4" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+color space used
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+YCbCr
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+JPEG 2000 RCT
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-chroma_planes 1 for color, 0 for grayscale
+chroma_planes indicates if chroma (color) planes are present.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="3" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+color space used
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+chroma planes are not present
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+chroma planes are present
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-bits_per_raw_sample The number of bits for each sample, commonly 8, 9, 10
- or 16
+bits_per_raw_sample bits_per_raw_sample
+\begin_inset Newline newline
+\end_inset
+
+indicates the number of bits for each luma and chroma sample.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-h_chroma_subsample The subsample factor between luma and chroma width (
+h_chroma_subsample indicates the subsample factor between luma and chroma
+ width (
 \begin_inset Formula $chroma\_width=2^{-log2\_h\_chroma\_subsample}luma\_width$
 \end_inset
 
@@ -6077,7 +6961,8 @@ h_chroma_subsample The subsample factor between luma and chroma width (
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-v_chroma_subsample The subsample factor between luma and chroma height (
+v_chroma_subsample indicates the subsample factor between luma and chroma
+ height (
 \begin_inset Formula $chroma\_height=2^{-log2\_v\_chroma\_subsample}luma\_height$
 \end_inset
 
@@ -6087,34 +6972,182 @@ v_chroma_subsample The subsample factor between luma and chroma height (
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
 \noindent
-alpha_plane 1 if a transparency plane is stored, 0 otherwise
+alpha_plane indicates if a transparency plane is present.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="3" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+color space used
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+transparency plane is not present
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+transparency plane is present
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-num_h_slices Number of horizontal elements of the slice raster
+num_h_slices indicates the number of horizontal elements of the slice raster.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-num_v_slices Number of vertical elements of the slice raster
+num_v_slices indicates the number of vertical elements of the slice raster.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-quant_table_count Number of quantization table sets
+quant_table_count indicates the number of quantization table sets.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-states_coded Flag that indicates if the respective quantization table set
- has the initial states coded or if they are all 128
+states_coded indicates if the respective quantization table set has the
+ initial states coded.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="3" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+initial states
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+initial states are not present and are assumed to be all 128
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+initial states are present
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-initial_state_delta[i][j][k] The initial range coder state, it is encoded
- using k as context index and
+initial_state_delta[i][j][k] indicates the initial range coder state, it
+ is encoded using k as context index and
 \begin_inset Newline newline
 \end_inset
 
@@ -6127,61 +7160,389 @@ initial_state[i][j][k]= (pred+initial_state_delta[i][j][k])&255
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-slice_count The number of slices in the current frame, slice_count is 1
- if it is not explicitly coded
+slice_count indicates the number of slices in the current frame, slice_count
+ is 1 if it is not explicitly coded.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-slice_x Slice x position on the slice raster formed by num_h_slices
+slice_x indicates the x position on the slice raster formed by num_h_slices.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-slice_y Slice y position on the slice raster formed by num_v_slices
+slice_y indicates the y position on the slice raster formed by num_v_slices.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-slice_width Slice width on the slice raster
+slice_width indicates the width on the slice raster.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-slice_height Slice height on the slice raster
+slice_height indicates the height on the slice raster.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-quant_table_index Index to select the quantization table set and the initial
- states for the slice
+quant_table_index indicates the index to select the quantization table set
+ and the initial states for the slice.
 \end_layout
 
 \begin_layout Labeling
 \labelwidthstring 12345678901234567890
-picture_structure 0(unknown) 1(top field first) 2(bottom field first) 3(progress
-ive)
-\end_layout
-
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
-sar_num/den Sample aspect ratio, 0/0 when unknown
-\end_layout
-
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
-ec error detection/correction type 0(32bit CRC on the global header), 1(32bit
- CRC per slice and the global header)
-\end_layout
-
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
-intra 0(key and non key frames), 1(the video contains only key frames)
+picture_structure specifies the picture structure.
 \begin_inset Newline newline
 \end_inset
 
-A value of 1 indicates also that frames are independant and that frame multithre
-ading is possible.
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="6" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+picure structure used
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+unknown
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+top field first
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+2
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+bottom field first
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+3
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+progressive
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Labeling
+\labelwidthstring 12345678901234567890
+sar_num specifies the sample aspect ratio numerator.
+\begin_inset Newline newline
+\end_inset
+
+Must be 0 if sample aspect ratio is unknown.
+\end_layout
+
+\begin_layout Labeling
+\labelwidthstring 12345678901234567890
+sar_den specifies the sample aspect ratio numerator.
+\begin_inset Newline newline
+\end_inset
+
+Must be 0 if sample aspect ratio is unknown.
+\end_layout
+
+\begin_layout Labeling
+\labelwidthstring 12345678901234567890
+ec indicates the error detection/correction type.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="4" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+error detection/correction type
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+32bit CRC on the global header
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+32bit CRC per slice and the global header
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Labeling
+\labelwidthstring 12345678901234567890
+intra indicates the relationship between frames.
+\begin_inset Newline newline
+\end_inset
+
+
+\begin_inset Tabular
+<lyxtabular version="3" rows="4" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="center" valignment="top">
+<column alignment="center" valignment="top">
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+value
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+relationship
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+0
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+frames are independent or dependent (key and non key frames)
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+1
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+frames are independent (key frames only)
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+Other
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" bottomline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+reserved for future use
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
 \end_layout
 
 \begin_layout Labeling

--- a/ffv1.lyx
+++ b/ffv1.lyx
@@ -4158,8 +4158,7 @@ u(32)
  
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 slice_coding_mode indicates the slice coding mode.
 \begin_inset Newline newline
 \end_inset
@@ -4257,8 +4256,7 @@ reserved for future use
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 slice_size indicates the size of the slice in bytes.
 \begin_inset Newline newline
 \end_inset
@@ -4268,8 +4266,7 @@ Note: this allows finding the start of slices before previous slices have
  And allows this way parallel decoding as well as error resilience.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 error_status specifies the error status.
 \begin_inset Newline newline
 \end_inset
@@ -4387,8 +4384,7 @@ reserved for future use
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 plane_count indicates the count of planes and the associated plane types.
 \begin_inset Newline newline
 \end_inset
@@ -6372,8 +6368,7 @@ u(32)
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
+\begin_layout Description
 \noindent
 version specifies the version of the bitstream.
 \begin_inset Newline newline
@@ -6517,8 +6512,7 @@ reserved for future use
  not exist, and this document does not describe them to keep the text simpler.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 00.00.0000
+\begin_layout Description
 micro_version specifies the micro version of the bitstream, each new micro
  version is compatible with the previous version.
 \begin_inset Newline newline
@@ -6625,8 +6619,7 @@ reserved for future use
 * were development versions which may be incompatible with the stable variants.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 coder_type specifies the coder used
 \begin_inset Newline newline
@@ -6745,8 +6738,7 @@ reserved for future use
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 state_transition_delta specifiies the range coder custom state transition
  table.
@@ -6757,8 +6749,7 @@ If state_transition_delta is not present in the bitstream, all range coder
  custom state transition table elements are assumed to be 0.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 colorspace_type specifies the color space.
 \begin_inset Newline newline
@@ -6857,8 +6848,7 @@ reserved for future use
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 chroma_planes indicates if chroma (color) planes are present.
 \begin_inset Newline newline
@@ -6937,8 +6927,7 @@ chroma planes are present
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 bits_per_raw_sample bits_per_raw_sample
 \begin_inset Newline newline
@@ -6947,8 +6936,7 @@ bits_per_raw_sample bits_per_raw_sample
 indicates the number of bits for each luma and chroma sample.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 h_chroma_subsample indicates the subsample factor between luma and chroma
  width (
@@ -6958,8 +6946,7 @@ h_chroma_subsample indicates the subsample factor between luma and chroma
 )
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 v_chroma_subsample indicates the subsample factor between luma and chroma
  height (
@@ -6969,8 +6956,7 @@ v_chroma_subsample indicates the subsample factor between luma and chroma
 )
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 \noindent
 alpha_plane indicates if a transparency plane is present.
 \begin_inset Newline newline
@@ -7049,23 +7035,19 @@ transparency plane is present
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 num_h_slices indicates the number of horizontal elements of the slice raster.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 num_v_slices indicates the number of vertical elements of the slice raster.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 quant_table_count indicates the number of quantization table sets.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 states_coded indicates if the respective quantization table set has the
  initial states coded.
 \begin_inset Newline newline
@@ -7144,8 +7126,7 @@ initial states are present
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 initial_state_delta[i][j][k] indicates the initial range coder state, it
  is encoded using k as context index and
 \begin_inset Newline newline
@@ -7158,40 +7139,33 @@ pred= j ? initial_states[i][j-1][k] : 128
 initial_state[i][j][k]= (pred+initial_state_delta[i][j][k])&255
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 slice_count indicates the number of slices in the current frame, slice_count
  is 1 if it is not explicitly coded.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 slice_x indicates the x position on the slice raster formed by num_h_slices.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 slice_y indicates the y position on the slice raster formed by num_v_slices.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 slice_width indicates the width on the slice raster.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 slice_height indicates the height on the slice raster.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 quant_table_index indicates the index to select the quantization table set
  and the initial states for the slice.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 picture_structure specifies the picture structure.
 \begin_inset Newline newline
 \end_inset
@@ -7329,8 +7303,7 @@ reserved for future use
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 sar_num specifies the sample aspect ratio numerator.
 \begin_inset Newline newline
 \end_inset
@@ -7338,8 +7311,7 @@ sar_num specifies the sample aspect ratio numerator.
 Must be 0 if sample aspect ratio is unknown.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 sar_den specifies the sample aspect ratio numerator.
 \begin_inset Newline newline
 \end_inset
@@ -7347,8 +7319,7 @@ sar_den specifies the sample aspect ratio numerator.
 Must be 0 if sample aspect ratio is unknown.
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 ec indicates the error detection/correction type.
 \begin_inset Newline newline
 \end_inset
@@ -7446,8 +7417,7 @@ reserved for future use
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 intra indicates the relationship between frames.
 \begin_inset Newline newline
 \end_inset
@@ -7545,8 +7515,7 @@ reserved for future use
 
 \end_layout
 
-\begin_layout Labeling
-\labelwidthstring 12345678901234567890
+\begin_layout Description
 crc_parity 32bit that are choosen so that the global header as a whole or
  slice as a whole has a crc remainder of 0.
  This is equivalent to storing the crc remainder in the 32bit parity.

--- a/ffv1.lyx
+++ b/ffv1.lyx
@@ -904,7 +904,7 @@ name "sub:Coding-of-the-sample-difference"
 
 \end_inset
 
-Coding of the sample difference 
+Coding of the sample difference
 \end_layout
 
 \begin_layout Standard
@@ -1301,7 +1301,7 @@ on of frame sizes and generally performs better than the default.
 \end_layout
 
 \begin_layout LyX-Code
-165,130,132,138,133,135,145,136,137,139,146,141,143,142,144,148, 
+165,130,132,138,133,135,145,136,137,139,146,141,143,142,144,148,
 \end_layout
 
 \begin_layout LyX-Code
@@ -7906,7 +7906,7 @@ Copyright
 \end_layout
 
 \begin_layout Standard
-Copyright 2003-2013 Michael Niedermayer <michaelni@gmx.at> 
+Copyright 2003-2013 Michael Niedermayer <michaelni@gmx.at>
 \begin_inset Newline newline
 \end_inset
 

--- a/ffv1.lyx
+++ b/ffv1.lyx
@@ -121,6 +121,172 @@ This document assumes familiarity with mathematical and coding concepts
 Terms and Definitions
 \end_layout
 
+\begin_layout Subsection
+Terms
+\end_layout
+
+\begin_layout Standard
+The key words "MUST", "MUST
+\begin_inset space ~
+\end_inset
+
+NOT", "SHOULD", and "SHOULD
+\begin_inset space ~
+\end_inset
+
+NOT" in this document are to be interpreted as described in RFC 2119 
+\begin_inset CommandInset citation
+LatexCommand cite
+key "RFC2119"
+
+\end_inset
+
+.
+\end_layout
+
+\begin_layout Standard
+For reference, below is an excerpt of RFC 2119:
+\end_layout
+
+\begin_layout Standard
+\begin_inset Tabular
+<lyxtabular version="3" rows="4" columns="2">
+<features rotate="0" tabularvalignment="middle">
+<column alignment="left" valignment="top">
+<column alignment="left" valignment="top">
+<row>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+\begin_inset Quotes eld
+\end_inset
+
+MUST
+\begin_inset Quotes erd
+\end_inset
+
+
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+means that the definition is an absolute requirement of the specification.
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+\begin_inset Quotes eld
+\end_inset
+
+MUST
+\begin_inset space ~
+\end_inset
+
+NOT
+\begin_inset Quotes erd
+\end_inset
+
+
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+means that the definition is an absolute prohibition of the specification.
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+\begin_inset Quotes eld
+\end_inset
+
+SHOULD
+\begin_inset Quotes erd
+\end_inset
+
+
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+means that there may exist valid reasons in particular circumstances to
+ ignore a particular item, but the full implications must be understood
+ and carefully weighed before choosing a different course.
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+\begin_inset Quotes eld
+\end_inset
+
+SHOULD
+\begin_inset space ~
+\end_inset
+
+NOT
+\begin_inset Quotes erd
+\end_inset
+
+
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="left" valignment="top" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+means that there may exist valid reasons in particular circumstances when
+ the particular behavior is acceptable or even useful, but the full implications
+ should be understood and the case carefully weighed before implementing
+ any behavior described with this label.
+ 
+\end_layout
+
+\end_inset
+</cell>
+</row>
+</lyxtabular>
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Subsection
+Definitions
+\end_layout
+
 \begin_layout Labeling
 \labelwidthstring 00.00.0000
 ESC Escape symbol to indicate that the symbol to be stored is too large
@@ -6508,8 +6674,11 @@ reserved for future use
 \begin_inset Newline newline
 \end_inset
 
-* Version 2 was never enabled in the encoder thus version 2 files should
- not exist, and this document does not describe them to keep the text simpler.
+* Version 2 was never enabled in the encoder thus version 2 files SHOULD
+\begin_inset space ~
+\end_inset
+
+NOT exist, and this document does not describe them to keep the text simpler.
 \end_layout
 
 \begin_layout Description
@@ -6518,7 +6687,11 @@ micro_version specifies the micro version of the bitstream, each new micro
 \begin_inset Newline newline
 \end_inset
 
-Decoders must not reject a file due to an unknown micro_version.
+Decoders MUST
+\begin_inset space ~
+\end_inset
+
+NOT reject a file due to an unknown micro_version.
 \begin_inset Newline newline
 \end_inset
 
@@ -7308,7 +7481,7 @@ sar_num specifies the sample aspect ratio numerator.
 \begin_inset Newline newline
 \end_inset
 
-Must be 0 if sample aspect ratio is unknown.
+MUST be 0 if sample aspect ratio is unknown.
 \end_layout
 
 \begin_layout Description
@@ -7316,7 +7489,7 @@ sar_den specifies the sample aspect ratio numerator.
 \begin_inset Newline newline
 \end_inset
 
-Must be 0 if sample aspect ratio is unknown.
+MUST be 0 if sample aspect ratio is unknown.
 \end_layout
 
 \begin_layout Description


### PR DESCRIPTION
This is the first patch of a serie of patches having the goal of being able to create a decoder only based on this specification, without having to rely on the FFV1 encoder/decoder implemented in FFmpeg. This document aims to be the base document for our proposal of FFV1 standardisation.
We currently focused on the header part of this document.