### PR TITLE
Add formating and conventions

### DIFF
--- a/ffv1.lyx
+++ b/ffv1.lyx
@@ -4555,7 +4555,7 @@ Slice Header
 
 \begin_layout Standard
 \begin_inset Tabular
-<lyxtabular version="3" rows="14" columns="2">
+<lyxtabular version="3" rows="15" columns="2">
 <features rotate="0" tabularvalignment="middle">
 <column alignment="left" valignment="top">
 <column alignment="center" valignment="top">
@@ -4930,7 +4930,7 @@ ur
 \begin_inset space ~
 \end_inset
 
-if( version > 3 )
+if( version > 3 ) {
 \end_layout
 
 \end_inset
@@ -5042,6 +5042,41 @@ slice_coding_mode
 
 \begin_layout Plain Layout
 ur
+\end_layout
+
+\end_inset
+</cell>
+</row>
+<row>
+<cell alignment="center" valignment="top" topline="true" leftline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+\begin_inset space ~
+\end_inset
+
+
+\begin_inset space ~
+\end_inset
+
+
+\begin_inset space ~
+\end_inset
+
+
+\begin_inset space ~
+\end_inset
+
+}
+\end_layout
+
+\end_inset
+</cell>
+<cell alignment="center" valignment="top" topline="true" leftline="true" rightline="true" usebox="none">
+\begin_inset Text
+
+\begin_layout Plain Layout
+
 \end_layout
 
 \end_inset


### PR DESCRIPTION
The purpose of this set of patches is to have a coherent document with explicit meaning of used operators.