### PR TITLE
WIP narrative explanation on Slice

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -537,6 +537,13 @@ Frame( ) {                                                    |
 
 ## Slice
 
+A `Slice` is a spatially distinct region of a `Frame` that is encoded separately from any other region of that `Frame`. A `Slice` is comprised the following four components in this storage order:
+
+- `SliceHeader` (Present if the `version` (see [the section on version](#version)) is greater than or equal to `3`)
+- `SliceContent` (MUST be present)
+- `padding` (If and only if the `coder_type` is equal to 0 (which indicates that the `Golomb Rice` coder is used) and the `SliceContent` is not `byte_aligned`, then the `SliceContent` MUST be followed with `padding` until `byte_aligned`.)
+- `SliceFooter` (Present if the `version` is greater than or equal to `3`.)
+
 ```c
 function                                                      | type
 --------------------------------------------------------------|-----


### PR DESCRIPTION
I think it may make the document more readable if some of the structure which is presently defined in code blocks is accompanied by a narrative description. Here’s an example of that approach for slice. This also includes an example of forward-referencing regarding ‘version’. Note: these references appear differently between the pandoc and mmark/rfc2xml outputs.
Comments welcome.