### PR TITLE
len - 1 is unsigned

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1223,7 +1223,7 @@ pseudo-code                                                   | type
 QuantizationTable(i, j, scale) {                              |
     v = 0                                                     |
     for( k = 0; k < 128; ) {                                  |
-        len - 1                                               | sr
+        len - 1                                               | ur
         for( a = 0; a < len; a++ ) {                          |
             quant_tables[ i ][ j ][ k ] = scale* v            |
             k++                                               |


### PR DESCRIPTION
len - 1 is a positive integer, sign is not useful, and actually current implementations do not store the sign, so `ur` instead of `sr`.