### PR TITLE
len_count related descriptions

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1213,7 +1213,7 @@ Inferred to be 0 if not present.
 
 ## Quantization Table Set
 
-The Quantization Table Sets are stored by storing the number of equal entries -1 of the first half of the table (represented as `len - 1` in the pseudo-code below) using the method described in [Range Non Binary Values](#range-non-binary-values). The second half doesn’t need to be stored as it is identical to the first with flipped sign.
+The Quantization Table Sets are stored by storing the number of equal entries -1 of the first half of the table (represented as `len - 1` in the pseudo-code below) using the method described in [Range Non Binary Values](#range-non-binary-values). The second half doesn’t need to be stored as it is identical to the first with flipped sign. `scale` and `len_count[ i ][ j ]` are temporary values used for the computing of `context_count[ i ]` and are not used outside Quantization Table Set pseudo-code.
 
 example:
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1230,7 +1230,7 @@ QuantizationTableSet( i ) {                                   |
         QuantizationTable( i, j, scale )                      |
         scale *= 2 * len_count[ i ][ j ] - 1                  |
     }                                                         |
-    context_count[ i ] = ( scale + 1 ) / 2                    |
+    context_count[ i ] = ceil ( scale / 2 )                   |
 }                                                             |
 ```
 


### PR DESCRIPTION
Attempt to fix https://github.com/FFmpeg/FFV1/issues/41 and replace the use as "/ 2" by the corresponding mathematic goal (especialy because the result of the division of a number is not clear, we don't explicitely say that all must be integers and that the cast to an integer should be with "floor" as current CPUs do)