### PR TITLE
JPEG2000-RCT exception clarification

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -336,7 +336,7 @@ RFC:```
 RFC:b=Cb+g
 RFC:```
 
-Exception for the JPEG2000-RCT conversion: if bits_per_raw_sample is between 9 and 15 inclusive, the following formulae for reversible conversions between YCbCr and RGB MUST be used instead of the ones above:
+Exception for the JPEG2000-RCT conversion: if bits_per_raw_sample is between 9 and 15 inclusive and alpha_plane is 0, the following formulae for reversible conversions between YCbCr and RGB MUST be used instead of the ones above:
 
 PDF:$$Cb=g-b$$
 RFC:```
@@ -368,7 +368,7 @@ RFC:```
 RFC:g=Cb+b
 RFC:```
 
-Background: At the time of this writing, in all known implementations of FFV1 bitstream, when bits_per_raw_sample was between 9 and 15 inclusive, GBR planes were used as BGR planes during both encoding and decoding. In the meanwhile, 16-bit JPEG2000-RCT was implemented without this issue in one implementation and validated by one conformance checker. Methods to address this exception for the transform are under consideration for the next version of the FFV1 bitstream.
+Background: At the time of this writing, in all known implementations of FFV1 bitstream, when bits_per_raw_sample was between 9 and 15 inclusive and alpha_plane is 0, GBR planes were used as BGR planes during both encoding and decoding. In the meanwhile, 16-bit JPEG2000-RCT was implemented without this issue in one implementation and validated by one conformance checker. Methods to address this exception for the transform are under consideration for the next version of the FFV1 bitstream.
 
 [@!ISO.15444-1.2016]
 


### PR DESCRIPTION
Currently, there is an exception in the generic bitstream description about the JPEG2000-RCT, because we don't want to break files in the wild for version 0 to 3:
"Exception for the JPEG2000-RCT conversion: if bits_per_raw_sample is between 9 and 15 inclusive, the following formulae for reversible conversions between YCbCr and RGB MUST be used instead of the ones above"

As all files in the wild with this exception are without alpha plane, and because the standard JPEG2000-RCT is known to be better for generic cases (I also tested a bit the compression with some 10/12-bit files I have, I see better compression ~3% without the exception for the few real world files I have, with some exceptions e.g. some artificially created files I have made show a slight worse compression) and also the 16-bit RGB files don't have this exception, I suggest to explicitly stipulate that the exception is for only the files in the wild, by adding " and alpha_plane is 0".

Then it is easy to adapt FFmpeg ("if (sizeof(TYPE) == 4)" becomes "if (sizeof(TYPE) == 4 || transparency)") and other encoders/decoders, and we can demonstrate how versatile FFV1 is.

As having no explicit information is not good for a spec, the other option would be to explicitly say that exception is for with and without alpha_plane, but I don't see a reason to do so (I see usage of different R/G/B coefficients in FFmpeg code for v4 experimental, but for v1-3 we need to choose 1 method for all streams).

Summary:
RGB with bit depth 1-8 & 16+, and RGBA any bit depth: no exception
RGB with bit depth 9-15: exception