### PR TITLE
CRC part is also possible with v0/v1

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -782,7 +782,13 @@ Slice( ) {                                                    |
     if (coder_type == 0)                                      |
         while (!byte_aligned())                               |
             padding                                           | u(1)
-    if (version >= 3)                                         |
+    if( version <= 1) {                                       |  
+        if (remaining_bits_in_bitstream( NumBytes ) == 40 )   |
+            ec = 1                                            |
+        else                                                  |
+            ec = 0                                            |
+    }                                                         |
+    if (version >= 3 || ec)                                   |
         SliceFooter( )                                        |
 }                                                             |
 ```
@@ -970,7 +976,8 @@ Note: slice footer is always byte aligned.
 pseudo-code                                                   | type
 --------------------------------------------------------------|-----
 SliceFooter( ) {                                              |
-    slice_size                                                | u(24)
+    if (version >= 3)                                         |
+        slice_size                                            | u(24)
     if (ec) {                                                 |
         error_status                                          | u(8)
         slice_crc_parity                                      | u(32)


### PR DESCRIPTION
FFmpeg permits to add CRC data after `SliceContent` in a v0/v1 stream (e.g. `./ffmpeg -f lavfi -i mandelbrot -t 1 -c ffv1 -slicecrc 1 a.mkv`), so we document it (for the moment, no extra data is expected after the `SliceContent` part in v0/v1, so the stream may be considered as invalid).
It is an implicit signaling (no `ec` metadata), so we detect the presence of CRC by checking if 5 bytes are remaining at the end of the frame.