### PR TITLE
Version 0 and 1 can have some content after SliceContent

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -782,6 +782,10 @@ Slice( ) {                                                    |
     if (coder_type == 0)                                      |
         while (!byte_aligned())                               |
             padding                                           | u(1)
+    if (version <= 1) {                                       |  
+        while (remaining_bits_in_bitstream( NumBytes ) != 0 ) |
+            reserved                                          | u(1)
+    }                                                         |
     if (version >= 3)                                         |
         SliceFooter( )                                        |
 }                                                             |
@@ -789,6 +793,11 @@ Slice( ) {                                                    |
 
 `padding` specifies a bit without any significance and used only for byte alignment.
 MUST be 0.
+
+`reserved` specifies a bit without any significance in this revision of the specification and may have a significance in a later revision of this specification.  
+Encoders SHOULD NOT fill these bits.  
+Decoders SHOULD ignore these bits.  
+Note in case these bits are used in a later revision of this specification: any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` for version 0 and 1 of the bitstream. Background: due to some non conforming encoders, some bitstreams where found with 40 extra bits corresponding to `error_status` and `slice_crc_parity`, a decoder conforming to the revised specification could not do the difference between a revised bitstream and a buggy bitstream.
 
 ## Slice Header
 


### PR DESCRIPTION
From the debate in https://github.com/FFmpeg/FFV1/pull/110, I propose a different method for avoiding to have streams created by ` "ffmpeg -c ffv1 -level 1 -slicecrc 1` considered as non conforming to specification.

This patch synchronizes specification with behavior of the decoder (which ignores the extra bits) by permitting the extra bits. It also add a note for people who would revise the specification about the risk of using 40 bits of the reserved part.

This patch does not prevent us to change our mind about https://github.com/FFmpeg/FFV1/pull/110 in the future.

Additional note: the extra bits are authorized only for versions 0 and 1 due to the existence of such bistream (not expected, but they are there) in the wild. "feature" of not having extra bits in version 3 is used by some decoders for being able to decode first slices (when latest bytes of a frame are missing, FFmpeg decoder decodes only the first slice, my own decoder uses the lack of reserved bits in the bitstream for parsing all slices up to the missing bytes by starting from the beginning and parsing all slices sequentially).