### PR TITLE
Change ffv1 0,1,3 to informative type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SRC=ffv1.md
 PDF=$(SRC:.md=.pdf)
 HTML=$(SRC:.md=.html)
-VERSION=02
+VERSION=03
 VERSION-v4=00
 
 $(info PDF and HTML rendering has been tested with pandoc version 1.13.2.1, some older versions are known to produce very poor output, please ensure your pandoc is recent enough.)

--- a/rfc_frontmatter.md
+++ b/rfc_frontmatter.md
@@ -1,9 +1,10 @@
 % Title = "FFV1 Video Coding Format Version 0, 1, and 3"{V3}
 % Title = "FFV1 Video Coding Format Version 4"{V4}
 % abbrev = "FFV1"
-% category = "std"
 % docName = "draft-ietf-cellar-ffv1-02"{V3}
 % docName = "draft-ietf-cellar-ffv1-v4-00"{V4}
+% category = "info"{V3}
+% category = "std"{V4}
 % ipr= "trust200902"
 % area = "art"
 % workgroup = "cellar"

--- a/rfc_frontmatter.md
+++ b/rfc_frontmatter.md
@@ -1,7 +1,7 @@
 % Title = "FFV1 Video Coding Format Version 0, 1, and 3"{V3}
 % Title = "FFV1 Video Coding Format Version 4"{V4}
 % abbrev = "FFV1"
-% docName = "draft-ietf-cellar-ffv1-02"{V3}
+% docName = "draft-ietf-cellar-ffv1-03"{V3}
 % docName = "draft-ietf-cellar-ffv1-v4-00"{V4}
 % category = "info"{V3}
 % category = "std"{V4}


### PR DESCRIPTION
This changes `draft-ietf-cellar-ffv1` from `Standards Track` categorization to `Informative` as discussed at the [last cellar meeting](https://datatracker.ietf.org/meeting/interim-2018-cellar-01/materials/minutes-interim-2018-cellar-01-201805292000). Since there are no commits impacting `draft-ietf-cellar-ffv1-v4` since the last version bump, I only bumped the version for ``draft-ietf-cellar-ffv1` (versions 0,1,3).