### PR TITLE
bump version to ffv1-04, ffv1-v4-01

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SRC=ffv1.md
 PDF=$(SRC:.md=.pdf)
 HTML=$(SRC:.md=.html)
-VERSION=03
-VERSION-v4=00
+VERSION=04
+VERSION-v4=01
 
 $(info PDF and HTML rendering has been tested with pandoc version 1.13.2.1, some older versions are known to produce very poor output, please ensure your pandoc is recent enough.)
 $(info RFC rendering has been tested with mmark version 1.3.4 and xml2rfc 2.5.1, please ensure these are installed and recent enough.)

--- a/rfc_frontmatter.md
+++ b/rfc_frontmatter.md
@@ -1,8 +1,8 @@
 % Title = "FFV1 Video Coding Format Version 0, 1, and 3"{V3}
 % Title = "FFV1 Video Coding Format Version 4"{V4}
 % abbrev = "FFV1"
-% docName = "draft-ietf-cellar-ffv1-03"{V3}
-% docName = "draft-ietf-cellar-ffv1-v4-00"{V4}
+% docName = "draft-ietf-cellar-ffv1-04"{V3}
+% docName = "draft-ietf-cellar-ffv1-v4-01"{V4}
 % category = "info"{V3}
 % category = "std"{V4}
 % ipr= "trust200902"


### PR DESCRIPTION
Given @mcr's comments "Internet Drafts are cheap documents, please do not treat them as more than
"draft"s... submit often.", I propose a new release. I can them update the cellar docs and follow up on the review which led to most of the recent commits. I suggest following this merge with a new release `draft-ietf-cellar-ffv1-02_v4-01`.