### PR TITLE
Add an exception for sar_den when aspect ratio is unknown

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1106,13 +1106,17 @@ Inferred to be 0 if not present.
 
 `sar_num` specifies the sample aspect ratio numerator.  
 Inferred to be 0 if not present.  
-MUST be 0 if sample aspect ratio is unknown.
+A value of 0 means that aspect ratio is unknown.  
+Encoders MUST write 0 if sample aspect ratio is unknown.  
+If `sar_den` is 0, decoders SHOULD ignore the encoded value and consider that `sar_num` is 0.
 
 ### sar_den
 
 `sar_den` specifies the sample aspect ratio denominator.  
 Inferred to be 0 if not present.  
-MUST be 0 if sample aspect ratio is unknown.
+A value of 0 means that aspect ratio is unknown.  
+Encoders MUST write 0 if sample aspect ratio is unknown.  
+If `sar_num` is 0, decoders SHOULD ignore the encoded value and consider that `sar_den` is 0.
 
 ### reset_contexts{V4}
 


### PR DESCRIPTION
Fix #109.
I prefer to explicitly handle the value used by FFmpeg instead of [the other proposal](https://github.com/FFmpeg/FFV1/issues/109#issuecomment-370037367), but I would not be against the other proposal if preferred by others.