### PR TITLE
adds a step to encode and embed svg image data into the rfc xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HTML=$(SRC:.md=.html)
 VERSION=08
 VERSION-v4=05
 
-$(info RFC rendering has been tested with mmark version 2.0.48, xml2rfc 2.23.1, xmlstarlet 1.6.1, pdfcrop v1.38, and pdf2svg 0.2.3, please ensure these are installed and recent enough.)
+$(info RFC rendering has been tested with mmark version 2.0.48, xml2rfc 2.23.1, xmlstarlet 1.6.1, pdfcrop v1.38, pdf2svg 0.2.3, and Python 2.7.16, please ensure these are installed and recent enough.)
 
 all: draft-ietf-cellar-ffv1-$(VERSION).html draft-ietf-cellar-ffv1-v4-$(VERSION-v4).html draft-ietf-cellar-ffv1-$(VERSION).txt draft-ietf-cellar-ffv1-v4-$(VERSION-v4).txt
 
@@ -12,6 +12,7 @@ draft-ietf-cellar-ffv1-$(VERSION).html: ffv1.md
 	bash makesvg
 	cat rfc_frontmatter.md "$<" rfc_backmatter.md | grep -v "^RFC:" | grep -v "^SVGC" | grep -v "{V4}" |  sed "s|^RFC:||g;s|{V3}||g;s|SVGI:||g" > merged_rfchtml.md
 	mmark merged_rfchtml.md > draft-ietf-cellar-ffv1-$(VERSION).xml
+	bash svg2src draft-ietf-cellar-ffv1-$(VERSION).xml
 	xml2rfc --html --v3 draft-ietf-cellar-ffv1-$(VERSION).xml -o "$@"
 
 draft-ietf-cellar-ffv1-v4-$(VERSION-v4).html: ffv1.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository manages the development of specification documents for FFV1, a l
 
 The FFV1 specification was initially written in lyx. In July 2015 the formatting of the specification was transitioned to Markdown to be used with xml2rfc version 2. In August 2019 the formatting was transitioned to target [xml2rfc version 3](https://tools.ietf.org/html/rfc7991).
 
-The Markdown version of the FFV1 specification may also be converted into XML, HTML, and text formats as an IETF RFC draft based on [xml2rfc version 3](https://tools.ietf.org/html/rfc7991). Producing the RFC formats requires mmark version 2.0.48 or higher, xml2rfc version 2.23.1 or higher, xmlstarlet 1.6.1 or higher, pdfcrop v1.38 or higher, and pdf2svg 0.2.3 or higher.
+The Markdown version of the FFV1 specification may also be converted into XML, HTML, and text formats as an IETF RFC draft based on [xml2rfc version 3](https://tools.ietf.org/html/rfc7991). Producing the RFC formats requires mmark version 2.0.48 or higher, xml2rfc version 2.23.1 or higher, xmlstarlet 1.6.1 or higher, pdfcrop v1.38 or higher, pdf2svg 0.2.3 or higher, and Python 2.7.16 or higher.
 
 Note that within ffv1.md lines that are prefixed with `SVGI:` refer to an embedded svg image as described in https://mmark.nl/post/syntax/#rfc-7991-xml-output. LaTeX expressions are provided with a `SVGC:` prefix in the form of `SVGC:filename=LaTeX_formula`. Throughout ffv1.md, ASCII-art representations are provided for each LaTeX formula with `RFC:` prefixes. Lines prefixed with `RFC` are removed from outputs that support SVG images and lines prefixed with `SVG` are removed from outputs that do not support SVG images.
 

--- a/svg2src
+++ b/svg2src
@@ -1,0 +1,7 @@
+#!/bin/bash
+# this script reads an RFC xml document and when an artwork node references a sidecar .svg file in the @src attribute, then this script replaces the file reference with the url-encoded image data of that file (as permitted by https://tools.ietf.org/html/rfc7991#section-2.5)
+RFC_XML="${1}"
+xmlstarlet select --template --match "//artwork[@type='svg'][substring(@src,string-length(@src)-3)='.svg']" --value-of @src --nl "${RFC_XML}" | while read ARTWORK_SVG ; do
+  ENCODED_SVG="$(echo $(cat "$ARTWORK_SVG") | python -c "import urllib;print urllib.quote(raw_input())")"
+  xmlstarlet edit --inplace --update "//artwork[@src='${ARTWORK_SVG}']/@src" --value "data:image/svg+xml,${ENCODED_SVG}" "${RFC_XML}"
+done


### PR DESCRIPTION
This allows the RFC xml to be independent without needing the sidecar svg files and thus can be used in IETF rfc2xml version 3 tools such as https://xml2rfc.tools.ietf.org/experimental.html

This PR uses the 3rd option described in https://tools.ietf.org/html/rfc7991#section-2.5 for embedding svg image data into the artwork tag. The svg xml encoded is done by piping it through `python -c "import urllib;print urllib.quote(raw_input())"`. I wasn't able to find a way to do this within the Makefile: search the xml for svg file references, encode the svg xml, and then to update the xml file from the image file reference to the image encoded data. So I opted to do this in a sidecar bash file. Suggestions welcome, though this works for me.