### PR TITLE
Limit context_count to what the implementation supports

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1462,7 +1462,7 @@ QuantizationTable(i, j, scale) {                              |
 
 ### context_count
 
-`context_count[ i ]` indicates the count of contexts for Quantization Table Set `i`.
+`context_count[ i ]` indicates the count of contexts for Quantization Table Set `i`. `context_count[ i ]` MUST be less than or equal 32768.
 
 # Restrictions
 


### PR DESCRIPTION
I think we do not have a limit for this in the spec

Using a limit above what actual implementations support would fail the goal
of documenting the existing FFV1 bitstream.
This limit can be lifted in future versions if there is a reason for doing so.

The value cannot be arbitrary as it would require terrabytes of storage per table set
in worst case.
Also values above what fits in 16bit would require implementations to use larger data
elements.

Signed-off-by: Michael Niedermayer <michael@niedermayer.cc>