### PR TITLE
Limit quant_table_set_count to what the reference decoder currently supports

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -958,7 +958,7 @@ Inferred to be 1 if not present.
 
 ### quant\_table\_set\_count
 
-`quant_table_set_count` indicates the number of Quantization Table Sets.
+`quant_table_set_count` indicates the number of Quantization Table Sets. `quant_table_set_count` MUST be less than or equal to 8.
 
 Inferred to be 1 if not present.
 


### PR DESCRIPTION
Fix #163. 
As discussed in the issue ticket, this value is arbitrary, compatible with all known implementations, and we could raise the value in a future version of the spec if there is an advantage demonstrated.
