### PR TITLE
V4 ieee crc

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1404,9 +1404,10 @@ Note: this allows finding the start of slices before previous slices have been f
 
 `slice_crc_parity` 32 bits that are chosen so that the slice as a whole has a crc remainder of 0.
 
-This is equivalent to storing the crc remainder in the 32-bit parity.
+This is equivalent to storing the crc remainder in the 32-bit parity. {V3}
 
-The CRC generator polynomial used is the standard IEEE CRC polynomial (0x104C11DB7), with initial value 0, without pre-inversion and without post-inversion.
+The CRC generator polynomial used is the standard IEEE CRC polynomial (0x104C11DB7), with initial value 0, without pre-inversion and without post-inversion. {V3}
+The CRC generator polynomial used is the standard IEEE CRC polynomial (0x104C11DB7), with initial value 0, with pre-inversion and with post-inversion. {V4}
 
 ## Quantization Table Set
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1045,9 +1045,7 @@ Decoders conforming to this version of this specification SHALL ignore its value
 
 `configuration_record_crc_parity` 32 bits that are chosen so that the `Configuration Record` as a whole has a crc remainder of 0.
 
-This is equivalent to storing the crc remainder in the 32-bit parity.
-
-The CRC generator polynomial used is the standard IEEE CRC polynomial (0x104C11DB7) with initial value 0.
+See slice_crc_parity for details.
 
 ### Mapping FFV1 into Containers
 


### PR DESCRIPTION
Using inversion should protect against added zero bytes before and after a CRC protected "block" of bytes. So this would update the spec accordingly for inversion in v4