### PR TITLE
JPEG2000-RCT Cb and Cr offset

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -347,6 +347,8 @@ AART:g=Cb+b
 
 Background: At the time of this writing, in all known implementations of FFV1 bitstream, when bits_per_raw_sample was between 9 and 15 inclusive and extra_plane is 0, GBR `Planes` were used as BGR `Planes` during both encoding and decoding. In the meanwhile, 16-bit JPEG2000-RCT was implemented without this issue in one implementation and validated by one conformance checker. Methods to address this exception for the transform are under consideration for the next version of the FFV1 bitstream.
 
+Cb and Cr are positively offseted by `1 << bits_per_raw_sample` after the conversion from RGB to the modified YCbCr and are negatively offseted by the same value before the conversion from the modified YCbCr to RGB, in order to have only non-negative values after the conversion.
+
 When FFV1 uses the JPEG2000-RCT, the horizontal `Lines` are interleaved to improve caching efficiency since it is most likely that the JPEG2000-RCT will immediately be converted to RGB during decoding. The interleaved coding order is also Y, then Cb, then Cr, and then if used transparency.
 
 As an example, a `Frame` that is two `Pixels` wide and two `Pixels` high, could comprise the following structure:


### PR DESCRIPTION
Fix https://github.com/FFmpeg/FFV1/issues/182.

My initial thought was to edit the formulas but in my opinion it is overloading them too much, less readable, for not n obvious added value, so I preferred a small new paragraph only.