### PR TITLE
Clarification about Parameters() intra field values

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1012,14 +1012,14 @@ AART:       ( pred + initial_state_delta[ i ][ j ][ k ] ) & 255
 
 ### intra
 
-`intra` indicates the relationship between the instances of `Frame`.
+`intra` indicates the constraint on `keyframe` in each instance of `Frame`.
 
 Inferred to be 0 if not present.
 
 |value  | relationship                                                     |
 |-------|:-----------------------------------------------------------------|
-|0      | Frames are independent or dependent (keyframes and non keyframes)|
-|1      | Frames are independent (keyframes only)                          |
+|0      | `keyframe` can be 0 or 1 (non keyframes or keyframes)            |
+|1      | `keyframe` MUST be 1 (keyframes only)                            |
 |Other  | reserved for future use                                          |
 
 ## Configuration Record


### PR DESCRIPTION
There may be some misunderstanding about `intra` field in `Parameters`, with some mix with `keyframe` field in `Frame` as seen on CELLAR.
The reference decoder reads this value but ignores it (no impact on the decoding).

This PR clarifies the link between `intra` field in `Parameters` and `keyframe` field in each `Frame`, and make explicit that `intra` value of 1 has no impact on the decoding process (it is only an hint).

