### PR TITLE
[WIP] Support for encodings using floating-point values

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -35,7 +35,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 `MSB`:   Most Significant Bit, the bit that can cause the largest change in magnitude of the symbol.
 
-`RCT`:   Reversible Color Transform, a near linear, exactly reversible integer transform that converts between RGB and YCbCr representations of a `Pixel`.
+`RCT`:   Reversible Color Transform, a near linear, exactly reversible transform that converts between RGB and YCbCr representations of a `Pixel`.
 
 `VLC`:   Variable Length Code, a code that maps source symbols to a variable number of bits.
 
@@ -910,17 +910,23 @@ If state_transition_delta is not present in the FFV1 bitstream, all Range coder 
 
 ### colorspace_type
 
-`colorspace_type` specifies the color space encoded, the pixel transformation used by the encoder, the extra plane content, as well as interleave method.
+`colorspace_type` specifies the color space encoded, the pixel transformation used by the encoder, the extra plane content, interleave method, as well as the format of each `Pixel`.
 
-|value  | color space encoded     | pixel transformation    | extra plane content     | interleave method       |
-|-------|:------------------------|:------------------------|:------------------------|:------------------------|
-| 0     | YCbCr                   | None                    | Transparency            | `Plane` then `Line`     |
-| 1     | RGB                     | JPEG2000-RCT            | Transparency            | `Line` then `Plane`     |
-| Other | reserved for future use | reserved for future use | reserved for future use | reserved for future use |
+|value  | color space encoded     | pixel transformation    | extra plane content     | interleave method       | Format
+|-------|:------------------------|:------------------------|:------------------------|:------------------------|--------
+| 0     | YCbCr                   | None                    | Transparency            | `Plane` then `Line`     | Integer
+| 1     | RGB                     | JPEG2000-RCT            | Transparency            | `Line` then `Plane`     | Integer
+| 2     | YCbCr                   | None                    | Transparency            | `Plane` then `Line`     | IEEE 754
+| 3     | RGB                     | JPEG2000-RCT            | Transparency            | `Line` then `Plane`     | IEEE 754
+| Other | reserved for future use | reserved for future use | reserved for future use | reserved for future use | reserved for future use
 
 Restrictions:
 
-If `colorspace_type` is 1, then `chroma_planes` MUST be 1, `log2_h_chroma_subsample` MUST be 0, and `log2_v_chroma_subsample` MUST be 0.
+If `colorspace_type` is 1 or 3, then `chroma_planes` MUST be 1, `log2_h_chroma_subsample` MUST be 0, and `log2_v_chroma_subsample` MUST be 0.
+
+If `colorspace_type` is 2 or 3, then `bits_per_raw_sample` MUST be one of the values supported by IEEE 754 (at the moment of writing: 16, 32, 64, 80, 128, 256; in practice only values 16 and 32 are usable).
+
+Note: IEEE 754 `Pixels` are handled exactly the same way as integer `Pixels` during the decoding process, except that the resulting values are flagged as floating-point numbers rather than integers.
 
 ### chroma_planes
 


### PR DESCRIPTION
This pull request expands FFV1 to provide lossless compression to additional pixel formats by adding floating-point values support, and permits the lossless encoding and decoding of the following FFmpeg currently existing floating-point values “pix_fmt” (AV_PIX_FMT_GBRPF32, AV_PIX_FMT_GBRAPF32, AV_PIX_FMT_GRAYF32) as well as their (not yet existing) 16-bit counterparts.
Video formats such as EXR can use floating-point values.

Note about the implementation in FFmpeg: As FFmpeg does not (yet) support 16-bit floating point RGB pixel formats, I plan to send a patch for ffv1dec using exactly the same method of decoding as FFmpeg handles EXR (using of the lossy conversion to integer function from EXR implementation after FFV1 decoding, no encoding), with a decoding message about the lossy decoding from the conversion. The additional complexity is minimal (a test on `colorspace_type` in order to apply the float to int conversion after decoding).

Note about the YCbCr part: as FFmpeg has AV_PIX_FMT_GRAYF32, I prefer to anticipate the support of such pix_fmt in order to have a coherent specification, by just increasing the `colorspace_type` value by 2 for each previous `colorspace_type` values.

Potential optimizations: In practice for 16-bit content not all bits are used (bit 15 is the sign and so always 0 and bit 14 is for more than 1.0 and so always 0); however, in theory it is possible to have values that are negative or greater than 1 (see AllHalfValues.exr description
 in https://github.com/AcademySoftwareFoundation/openexr-images/tree/master/TestImages ) so we can not simply omit these bits in the Parameters. Optimization about reducing the bit depth requires more complex changes (similar to how we could reduce Y bit depth to bit_depth instead of `bit_depth+1` with `colorspace_type` of 1, as Only Cb and Cr have a range of `bit_depth+1` bits) which would be implemented in version 4. The idea of the implementation in version 3 is to keep the decoder nearly untouched.

This [link](https://we.tl/t-i6vcrU55t7) has some sample files as a proof of concept (the `colorspace_type` value in the FFV1 bitstream is wrong for both the DPX header and FFV1 bitstream but permits to decode the floating-point numbers from current FFmpeg; FFmpeg patches are hacks for moving the float to int algo from EXR decoder to FFV1 decoder).
