### PR TITLE
Adjust appendices

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1446,7 +1446,7 @@ QuantizationTableSet( i ) {                                   |
 }                                                             |
 ```
 
-MAX\_CONTEXT\_INPUTS is 5.
+`MAX_CONTEXT_INPUTS` is 5.
 
 ```c
 pseudo-code                                                   | type

--- a/ffv1.md
+++ b/ffv1.md
@@ -1172,8 +1172,6 @@ Encoders SHOULD NOT fill these bits.
 
 Decoders SHOULD ignore these bits.
 
-Note in case these bits are used in a later revision of this specification: any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` for `version` 0 and 1 of the bitstream. Background: Due to some non-conforming encoders, some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity`. As a result, a decoder conforming to the revised specification could not distinguish between a revised bitstream and a buggy bitstream.
-
 ## Slice Header
 
 A `Slice Header` provides information about the decoding configuration of the `Slice`, such as its spatial position, size, and aspect ratio. The pseudo-code below describes the contents of the `Slice Header`.
@@ -1580,6 +1578,10 @@ The IANA is requested to register the following values:
 The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
 
 After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
+
+# Appendix B: Future handling of some streams created by non conforming encoders
+
+Some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity` in the `reserved` bits of `Slice()`. Any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` if `version` == 0 or `version` == 1. Else a decoder conforming to the revised specification could not distinguish between a revised bitstream and such buggy bitstream in the wild.
 
 # Changelog
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -35,15 +35,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 `MSB`:   Most Significant Bit, the bit that can cause the largest change in magnitude of the symbol.
 
-`RCT`:   Reversible Color Transform, a near linear, exactly reversible integer transform that converts between RGB and YCbCr representations of a `Pixel`.
-
 `VLC`:   Variable Length Code, a code that maps source symbols to a variable number of bits.
 
 `RGB`:   A reference to the method of storing the value of a `Pixel` by using three numeric values that represent Red, Green, and Blue.
 
 `YCbCr`: A reference to the method of storing the value of a `Pixel` by using three numeric values that represent the luma of the `Pixel` (Y) and the chrominance of the `Pixel` (Cb and Cr). YCbCr word is used for historical reasons and currently references any color space relying on 1 luma `Sample` and 2 chrominance `Samples`, e.g. YCbCr, YCgCo or ICtCp. The exact meaning of the three numeric values is unspecified.
 
-`TBA`:   To Be Announced. Used in reference to the development of future iterations of the FFV1 specification.
+`TBA`:   To Be Announced. Used in reference to the development of future iterations of the FFV1 specification. {V4}
 
 ## Conventions
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -29,7 +29,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 `Plane`: A discrete component of a static image comprised of `Samples` that represent a specific quantification of `Samples` of that image.
 
-`Pixel`: The smallest addressable representation of a color in a `Frame`. It is composed of 1 or more `Samples`.
+`Pixel`: The smallest addressable representation of a color in a `Frame`. It is composed of one or more `Samples`.
 
 `ESC`:   An ESCape symbol to indicate that the symbol to be stored is too large for normal storage and that an alternate storage method is used.
 
@@ -53,7 +53,7 @@ The FFV1 bitstream is described in this document using pseudo-code. Note that th
 
 ### Arithmetic Operators
 
-Note: the operators and the order of precedence are the same as used in the C programming language [@!ISO.9899.2018]. With the exception of `>>` (removal of implementation defined behavior) and `^` (power instead of XOR) operators which are re-defined within this section.
+Note: the operators and the order of precedence are the same as used in the C programming language [@!ISO.9899.2018], with the exception of `>>` (removal of implementation defined behavior) and `^` (power instead of XOR) operators which are re-defined within this section.
 
 `a + b`       means a plus b.
 
@@ -71,7 +71,7 @@ Note: the operators and the order of precedence are the same as used in the C pr
 
 `a | b`       means bit-wise "or" of a and b.
 
-`a >> b`      means arithmetic right shift of two’s complement integer representation of a by b binary digits. This is equivalent to, b times dividing a by 2 with rounding toward negative infinity.
+`a >> b`      means arithmetic right shift of two’s complement integer representation of a by b binary digits. This is equivalent to dividing a by 2, b times, with rounding toward negative infinity.
 
 `a << b`      means arithmetic left shift of two’s complement integer representation of a by b binary digits.
 
@@ -250,7 +250,7 @@ top16s  = t  >= 32768 ? ( t  - 65536 ) : t
 diag16s = tl >= 32768 ? ( tl - 65536 ) : tl
 ```
 
-Background: a two's complement signed 16-bit signed integer was used for storing `Sample` values in all known implementations of FFV1 bitstream. So in some circumstances, the most significant bit was wrongly interpreted (used as a sign bit instead of the 16th bit of an unsigned integer). Note that when the issue is discovered, the only configuration of all known implementations being impacted is 16-bit YCbCr with no Pixel transformation with Range Coder coder, as other potentially impacted configurations (e.g. 15/16-bit JPEG2000-RCT with Range Coder coder, or 16-bit content with Golomb Rice coder) were implemented nowhere [@!ISO.15444-1.2016]. In the meanwhile, 16-bit JPEG2000-RCT with Range Coder coder was implemented without this issue in one implementation and validated by one conformance checker. It is expected (to be confirmed) to remove this exception for the median predictor in the next version of the FFV1 bitstream.
+Background: a two's complement signed 16-bit signed integer was used for storing `Sample` values in all known implementations of FFV1 bitstream. So in some circumstances, the most significant bit was wrongly interpreted (used as a sign bit instead of the 16th bit of an unsigned integer). Note that when the issue was discovered, the only configuration of all known implementations being impacted is 16-bit YCbCr with no Pixel transformation with Range Coder coder, as other potentially impacted configurations (e.g. 15/16-bit JPEG2000-RCT with Range Coder coder, or 16-bit content with Golomb Rice coder) were implemented nowhere [@!ISO.15444-1.2016]. In the meanwhile, 16-bit JPEG2000-RCT with Range Coder coder was implemented without this issue in one implementation and validated by one conformance checker. It is expected (to be confirmed) to remove this exception for the median predictor in the next version of the FFV1 bitstream.
 
 ## Context
 
@@ -270,7 +270,7 @@ If `context >= 0` then `context` is used and the difference between the `Sample`
 
 ## Quantization Table Sets
 
-The FFV1 bitstream contains 1 or more Quantization Table Sets. Each Quantization Table Set contains exactly 5 Quantization Tables with each Quantization Table corresponding to 1 of the 5 Quantized Sample Differences. For each Quantization Table, both the number of quantization steps and their distribution are stored in the FFV1 bitstream; each Quantization Table has exactly 256 entries, and the 8 least significant bits of the Quantized Sample Difference are used as index:
+The FFV1 bitstream contains one or more Quantization Table Sets. Each Quantization Table Set contains exactly 5 Quantization Tables with each Quantization Table corresponding to one of the five Quantized Sample Differences. For each Quantization Table, both the number of quantization steps and their distribution are stored in the FFV1 bitstream; each Quantization Table has exactly 256 entries, and the 8 least significant bits of the Quantized Sample Difference are used as index:
 
 SVGI:!---
 SVGI:![svg](quantizationtablesets.svg "quantization table sets")
@@ -347,7 +347,7 @@ AART:g=Cb+b
 
 Background: At the time of this writing, in all known implementations of FFV1 bitstream, when `bits_per_raw_sample` was between 9 and 15 inclusive and `extra_plane` is 0, GBR `Planes` were used as BGR `Planes` during both encoding and decoding. In the meanwhile, 16-bit JPEG2000-RCT was implemented without this issue in one implementation and validated by one conformance checker. Methods to address this exception for the transform are under consideration for the next version of the FFV1 bitstream.
 
-Cb and Cr are positively offseted by `1 << bits_per_raw_sample` after the conversion from RGB to the modified YCbCr and are negatively offseted by the same value before the conversion from the modified YCbCr to RGB, in order to have only non-negative values after the conversion.
+Cb and Cr are positively offset by `1 << bits_per_raw_sample` after the conversion from RGB to the modified YCbCr and are negatively offseted by the same value before the conversion from the modified YCbCr to RGB, in order to have only non-negative values after the conversion.
 
 When FFV1 uses the JPEG2000-RCT, the horizontal `Lines` are interleaved to improve caching efficiency since it is most likely that the JPEG2000-RCT will immediately be converted to RGB during decoding. The interleaved coding order is also Y, then Cb, then Cr, and then if used transparency.
 
@@ -448,17 +448,17 @@ AART:j_{0} = 2
 
 ##### Termination
 
-The range coder can be used in 3 modes.
+The range coder can be used in three modes.
 
 * In `Open mode` when decoding, every symbol the reader attempts to read is available. In this mode arbitrary data can have been appended without affecting the range coder output. This mode is not used in FFV1.
 
-* In `Closed mode` the length in bytes of the bytestream is provided to the range decoder. Bytes beyond the length are read as 0 by the range decoder. This is generally 1 byte shorter than the open mode.
+* In `Closed mode` the length in bytes of the bytestream is provided to the range decoder. Bytes beyond the length are read as 0 by the range decoder. This is generally one byte shorter than the open mode.
 
 * In `Sentinel mode` the exact length in bytes is not known and thus the range decoder MAY read into the data that follows the range coded bytestream by one byte. In `Sentinel mode`, the end of the range coded bytestream is a binary symbol with state 129, which value SHALL be discarded. After reading this symbol, the range decoder will have read one byte beyond the end of the range coded bytestream. This way the byte position of the end can be determined. Bytestreams written in `Sentinel mode` can be read in `Closed mode` if the length can be determined, in this case the last (sentinel) symbol will be read non-corrupted and be of value 0.
 
-Above describes the range decoding, encoding is defined as any process which produces a decodable bytestream.
+Above describes the range decoding. Encoding is defined as any process which produces a decodable bytestream.
 
-There are 3 places where range coder termination is needed in FFV1.
+There are three places where range coder termination is needed in FFV1.
 First is in the `Configuration Record`, in this case the size of the range coded bytestream is known and handled as `Closed mode`.
 Second is the switch from the `Slice Header` which is range coded to Golomb coded slices as `Sentinel mode`.
 Third is the end of range coded Slices which need to terminate before the CRC at their end. This can be handled as `Sentinel mode` or as `Closed mode` if the CRC position has been determined.
@@ -595,7 +595,7 @@ The end of the bitstream of the `Frame` is filled with 0-bits until that the bit
 
 #### Signed Golomb Rice Codes
 
-This coding mode uses Golomb Rice codes. The VLC is split into 2 parts, the prefix stores the most significant bits and the suffix stores the k least significant bits or stores the whole number in the ESC case.
+This coding mode uses Golomb Rice codes. The VLC is split into two parts. The prefix stores the most significant bits and the suffix stores the k least significant bits or stores the whole number in the ESC case.
 
 ```c
 pseudo-code                                                   | type
@@ -652,7 +652,7 @@ Run mode is entered when the context is 0 and left as soon as a non-0 difference
 
 ##### Run Length Coding
 
-The run value is encoded in 2 parts, the prefix part stores the more significant part of the run as well as adjusting the `run_index` that determines the number of bits in the less significant part of the run. The 2nd part of the value stores the less significant part of the run as it is. The run_index is reset for each `Plane` and slice to 0.
+The run value is encoded in two parts. The prefix part stores the more significant part of the run as well as adjusting the `run_index` that determines the number of bits in the less significant part of the run. The second part of the value stores the less significant part of the run as it is. The run_index is reset for each `Plane` and slice to 0.
 
 ```c
 pseudo-code                                                   | type
@@ -699,7 +699,7 @@ Level coding is identical to the normal difference coding with the exception tha
     }
 ```
 
-Note, this is different from JPEG-LS, which doesn’t use prediction in run mode and uses a different encoding and context model for the last difference On a small set of test `Samples` the use of prediction slightly improved the compression rate.
+Note, this is different from JPEG-LS, which doesn’t use prediction in run mode and uses a different encoding and context model for the last difference. On a small set of test `Samples` the use of prediction slightly improved the compression rate.
 
 #### Scalar Mode
 
@@ -759,7 +759,7 @@ At keyframes all coder state variables are set to their initial state.
 
 # Bitstream
 
-An FFV1 bitstream is composed of a series of 1 or more `Frames` and (when required) a `Configuration Record`.
+An FFV1 bitstream is composed of a series of one or more `Frames` and (when required) a `Configuration Record`.
 
 Within the following sub-sections, pseudo-code is used to explain the structure of each FFV1 bitstream component, as described in (#pseudo-code). [@tablePseudoCodeSymbols] lists symbols used to annotate that pseudo-code in order to define the storage of the data referenced in that line of pseudo-code.
 
@@ -902,7 +902,7 @@ Restrictions:
 
 If `coder_type` is 0, then `bits_per_raw_sample` SHOULD NOT be > 8.
 
-Background: At the time of this writing, there is no known implementations of FFV1 bitstream supporting Golomb Rice algorithm with `bits_per_raw_sample` greater than 8, and Range Coder is prefered.
+Background: At the time of this writing, there is no known implementation of FFV1 bitstream supporting Golomb Rice algorithm with `bits_per_raw_sample` greater than 8, and Range Coder is prefered.
 
 ### state\_transition\_delta
 
@@ -942,7 +942,7 @@ If `colorspace_type` is 1, then `chroma_planes` MUST be 1, `log2_h_chroma_subsam
 | 0     | reserved\*                                      |
 | Other | the actual bits for each `Sample`               |
 
-\* Encoders MUST NOT store `bits_per_raw_sample` = 0
+\* Encoders MUST NOT store `bits_per_raw_sample` = 0.
 Decoders SHOULD accept and interpret `bits_per_raw_sample` = 0 as 8.
 
 ### log2\_h\_chroma\_subsample
@@ -1059,9 +1059,9 @@ Decoders conforming to this version of this specification SHALL ignore its value
 
 ### configuration\_record\_crc\_parity
 
-`configuration_record_crc_parity` 32 bits that are chosen so that the `Configuration Record` as a whole has a crc remainder of 0.
+`configuration_record_crc_parity` 32 bits that are chosen so that the `Configuration Record` as a whole has a CRC remainder of 0.
 
-This is equivalent to storing the crc remainder in the 32-bit parity.
+This is equivalent to storing the CRC remainder in the 32-bit parity.
 
 The CRC generator polynomial used is the standard IEEE CRC polynomial (0x104C11DB7) with initial value 0.
 
@@ -1135,7 +1135,7 @@ Architecture overview of slices in a `Frame`:
 
 ## Slice
 
-A `Slice` is an independent spatial sub-section of a `Frame` that is encoded separately from an other region of the same `Frame`. The use of more than one `Slice` per `Frame` can be useful for taking advantage of the opportunities of multithreaded encoding and decoding.
+A `Slice` is an independent spatial sub-section of a `Frame` that is encoded separately from another region of the same `Frame`. The use of more than one `Slice` per `Frame` can be useful for taking advantage of the opportunities of multithreaded encoding and decoding.
 
 A `Slice` consists of a `Slice Header` (when relevant), a `Slice Content`, and a `Slice Footer` (when relevant). The pseudo-code below describes the contents of a `Slice`.
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1315,7 +1315,7 @@ SliceContent( ) {                                             |
 
 ### primary\_color\_count
 
-`primary_color_count` is defined as `1 + ( chroma_planes ? 2 : 0 ) + ( `extra_plane` ? 1 : 0 )`.
+`primary_color_count` is defined as `1 + ( chroma_planes ? 2 : 0 ) + ( extra_plane ? 1 : 0 )`.
 
 ### plane\_pixel\_height
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -842,11 +842,11 @@ CONTEXT_SIZE is 32.
 
 `version` specifies the version of the FFV1 bitstream.
 
-Each version is incompatible with other versions: decoders SHOULD reject a file due to an unknown version.
+Each version is incompatible with other versions: decoders SHOULD reject a content due to an unknown version.
 
-Decoders SHOULD reject a file with version <= 1 && ConfigurationRecordIsPresent == 1.
+Decoders SHOULD reject a content with `version` <= 1 && `ConfigurationRecordIsPresent` == 1.
 
-Decoders SHOULD reject a file with version >= 3 && ConfigurationRecordIsPresent == 0.
+Decoders SHOULD reject a content with `version` >= 3 && `ConfigurationRecordIsPresent` == 0.
 
 |value   | version                 |
 |:-------|:------------------------|
@@ -863,7 +863,7 @@ Decoders SHOULD reject a file with version >= 3 && ConfigurationRecordIsPresent 
 
 `micro_version` specifies the micro-version of the FFV1 bitstream.
 
-After a version is considered stable (a micro-version value is assigned to be the first stable variant of a specific version), each new micro-version after this first stable variant is compatible with the previous micro-version: decoders SHOULD NOT reject a file due to an unknown micro-version equal or above the micro-version considered as stable.
+After a version is considered stable (a micro-version value is assigned to be the first stable variant of a specific version), each new micro-version after this first stable variant is compatible with the previous micro-version: decoders SHOULD NOT reject a content due to an unknown micro-version equal or above the micro-version considered as stable.
 
 Meaning of `micro_version` for `version` 3:
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -113,25 +113,25 @@ Note: the operators and the order of precedence are the same as used in the C pr
 
 
 
-floor(a)              the largest integer less than or equal to a
+`floor(a)`              means the largest integer less than or equal to a.
 
-ceil(a)               the smallest integer greater than or equal to a
+`ceil(a)`               means the smallest integer greater than or equal to a.
 
-sign(a)               extracts the sign of a number, i.e. if a < 0 then -1, else if a > 0 then 1, else 0
+`sign(a)`               extracts the sign of a number, i.e. if a < 0 then -1, else if a > 0 then 1, else 0.
 
-abs(a)                the absolute value of a, i.e. abs(a) = sign(a)*a
+`abs(a)`                means the absolute value of a, i.e. `abs(a)` = `sign(a) * a`.
 
-log2(a)               the base-two logarithm of a
+`log2(a)`               means the base-two logarithm of a.
 
-min(a,b)              the smallest of two values a and b
+`min(a,b)`              means the smallest of two values a and b.
 
-max(a,b)              the largest of two values a and b
+`max(a,b)`              means the largest of two values a and b.
 
-median(a,b,c)         the numerical middle value in a data set of a, b, and c, i.e. a+b+c-min(a,b,c)-max(a,b,c)
+`median(a,b,c)`         means the numerical middle value in a data set of a, b, and c, i.e. a+b+c-min(a,b,c)-max(a,b,c).
 
-A <== B               B implies A
+`A <== B`               means B implies A.
 
-A <==> B              A <== B , B <== A
+`A <==> B`              means A <== B , B <== A.
 
 ### Order of Operation Precedence
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -630,7 +630,9 @@ int get_sr_golomb(k) {                                        |
 |              |                                                         |
 |:-------------|:--------------------------------------------------------|
 |non ESC       | the k least significant bits MSB first                  |
-|ESC           | the value - 11, in MSB first order, ESC may only be used if the value cannot be coded as non ESC|
+|ESC           | the value - 11, in MSB first order                      |
+
+`ESC` MUST NOT be used if the value can be coded as `non ESC`.
 
 ##### Examples
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1573,16 +1573,6 @@ The IANA is requested to register the following values:
 
    - Media type registration as described in (#media-type-definition).
 
-# Appendix A (informative): Multi-theaded decoder implementation suggestions
-
-The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
-
-After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
-
-# Appendix B (informative): Future handling of some streams created by non conforming encoders
-
-Some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity` in the `reserved` bits of `Slice()`. Any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` if `version` == 0 or `version` == 1. Else a decoder conforming to the revised specification could not distinguish between a revised bitstream and such buggy bitstream in the wild.
-
 # Changelog
 
 See <https://github.com/FFmpeg/FFV1/commits/master>

--- a/ffv1.md
+++ b/ffv1.md
@@ -769,6 +769,7 @@ Within the following sub-sections, pseudo-code is used to explain the structure 
 | br   | Range coded Boolean (1-bit) symbol with the method described in (#range-binary-values)           |
 | ur   | Range coded unsigned scalar symbol coded with the method described in (#range-non-binary-values) |
 | sr   | Range coded signed scalar symbol coded with the method described in (#range-non-binary-values)   |
+| sd   | Sample difference coded with the method described in (#coding-of-the-sample-difference)   |
 Table: Definition of pseudo-code symbols for this document. {#tablePseudoCodeSymbols}
 
 The same context that is initialized to 128 is used for all fields in the header.
@@ -1348,11 +1349,11 @@ pseudo-code                                                   | type
 Line( p, y ) {                                                |
     if (colorspace_type == 0) {                               |
         for (x = 0; x < plane_pixel_width[ p ]; x++) {        |
-            sample_difference[ p ][ y ][ x ]                  |
+            sample_difference[ p ][ y ][ x ]                  | sd
         }                                                     |
     } else if (colorspace_type == 1) {                        |
         for (x = 0; x < slice_pixel_width; x++) {             |
-            sample_difference[ p ][ y ][ x ]                  |
+            sample_difference[ p ][ y ][ x ]                  | sd
         }                                                     |
     }                                                         |
 }                                                             |

--- a/ffv1.md
+++ b/ffv1.md
@@ -1573,13 +1573,13 @@ The IANA is requested to register the following values:
 
    - Media type registration as described in (#media-type-definition).
 
-# Appendix A: Multi-theaded decoder implementation suggestions
+# Appendix A (informative): Multi-theaded decoder implementation suggestions
 
 The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
 
 After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
 
-# Appendix B: Future handling of some streams created by non conforming encoders
+# Appendix B (informative): Future handling of some streams created by non conforming encoders
 
 Some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity` in the `reserved` bits of `Slice()`. Any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` if `version` == 0 or `version` == 1. Else a decoder conforming to the revised specification could not distinguish between a revised bitstream and such buggy bitstream in the wild.
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -857,7 +857,7 @@ Decoders SHOULD reject a content with `version` >= 3 && `ConfigurationRecordIsPr
 |4       |  FFV1 version 4         |{V4}
 |Other   |  reserved for future use|
 
-\* Version 2 was never enabled in the encoder thus version 2 files SHOULD NOT exist, and this document does not describe them to keep the text simpler.
+\* Version 2 was never enabled in any known encoder. Decoders SHOULD reject a content with `version` == 2.
 
 ### micro\_version
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -232,21 +232,20 @@ The labels for these relative `Samples` are made of the first letters of the wor
 
 The prediction for any `Sample` value at position `X` may be computed based upon the relative neighboring values of `l`, `t`, and `tl` via this equation:
 
-`median(l, t, l + t - tl)`.
+median(l, t, l + t - tl)
 
 Note, this prediction template is also used in [@ISO.14495-1.1999] and [@HuffYUV].
 
 Exception for the median predictor:
 if `colorspace_type == 0 && bits_per_raw_sample == 16 && ( coder_type == 1 || coder_type == 2 )`, the following median predictor MUST be used:
 
-`median(left16s, top16s, left16s + top16s - diag16s)`
+median(left16s, top16s, left16s + top16s - diag16s)
 
 where:
-```
+
 left16s = l  >= 32768 ? ( l  - 65536 ) : l
 top16s  = t  >= 32768 ? ( t  - 65536 ) : t
 diag16s = tl >= 32768 ? ( tl - 65536 ) : tl
-```
 
 Background: a two's complement signed 16-bit signed integer was used for storing `Sample` values in all known implementations of FFV1 bitstream. So in some circumstances, the most significant bit was wrongly interpreted (used as a sign bit instead of the 16th bit of an unsigned integer). Note that when the issue was discovered, the only configuration of all known implementations being impacted is 16-bit YCbCr with no Pixel transformation with Range Coder coder, as other potentially impacted configurations (e.g. 15/16-bit JPEG2000-RCT with Range Coder coder, or 16-bit content with Golomb Rice coder) were implemented nowhere [@!ISO.15444-1.2016]. In the meanwhile, 16-bit JPEG2000-RCT with Range Coder coder was implemented without this issue in one implementation and validated by one conformance checker. It is expected (to be confirmed) to remove this exception for the median predictor in the next version of the FFV1 bitstream.
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -950,7 +950,7 @@ Decoders SHOULD accept and interpret `bits_per_raw_sample` = 0 as 8.
 
 `log2_v_chroma_subsample` indicates the subsample factor, stored in powers to which the number 2 must be raised, between luma and chroma height (`chroma_height = 2 ^ -log2_v_chroma_subsample * luma_height`).
 
-### `extra\_plane`
+### extra\_plane
 
 `extra_plane` indicates if an extra `Plane` is present.
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1223,7 +1223,9 @@ Inferred to be 1 if not present.
 
 ### quant\_table\_set\_index\_count
 
-`quant_table_set_index_count` is defined as `1 + ( ( chroma_planes || version <= 3 ) ? 1 : 0 ) + ( `extra_plane` ? 1 : 0 )`.
+`quant_table_set_index_count` is defined as:
+
+1 + ( ( chroma\_planes || version <= 3 ) ? 1 : 0 ) + ( extra\_plane ? 1 : 0 )
 
 ### quant\_table\_set\_index
 
@@ -1315,27 +1317,27 @@ SliceContent( ) {                                             |
 
 ### primary\_color\_count
 
-`primary_color_count` is defined as `1 + ( chroma_planes ? 2 : 0 ) + ( extra_plane ? 1 : 0 )`.
+`primary_color_count` is defined as:
+
+1 + ( chroma\_planes ? 2 : 0 ) + ( extra\_plane ? 1 : 0 )
 
 ### plane\_pixel\_height
 
-`plane_pixel_height[ p ]` is the height in pixels of plane p of the slice.
+`plane_pixel_height[ p ]` is the height in `Pixels` of `Plane` p of the `Slice`. It is defined as:
 
-`plane_pixel_height[ 0 ]` and `plane_pixel_height[ 1 + ( chroma_planes ? 2 : 0 ) ]` value is `slice_pixel_height`.
-
-If `chroma_planes` is set to 1, `plane_pixel_height[ 1 ]` and `plane_pixel_height[ 2 ]` value is `ceil( slice_pixel_height / (1 << log2_v_chroma_subsample) )`.
+(chroma\_planes == 1 && (p == 1 || p == 2)) ? ceil(slice\_pixel\_height / (1 << log2\_v\_chroma\_subsample)) : slice\_pixel\_height
 
 ### slice\_pixel\_height
 
-`slice_pixel_height` is the height in pixels of the slice.
+`slice_pixel_height` is the height in pixels of the slice. It is defined as:
 
-Its value is `floor( ( slice_y + slice_height ) * slice_pixel_height / num_v_slices ) - slice_pixel_y`.
+floor( ( slice\_y + slice\_height ) \* slice\_pixel\_height / num\_v\_slices ) - slice\_pixel\_y.
 
 ### slice\_pixel\_y
 
-`slice_pixel_y` is the slice vertical position in pixels.
+`slice_pixel_y` is the slice vertical position in pixels. It is defined as:
 
-Its value is `floor( slice_y * frame_pixel_height / num_v_slices )`.
+floor( slice_y \* frame\_pixel\_height / num\_v\_slices )
 
 ## Line
 
@@ -1359,23 +1361,21 @@ Line( p, y ) {                                                |
 
 ### plane\_pixel\_width
 
-`plane_pixel_width[ p ]` is the width in `Pixels` of `Plane` p of the slice.
+`plane_pixel_width[ p ]` is the width in `Pixels` of `Plane` p of the `Slice`. It is defined as:
 
-`plane_pixel_width[ 0 ]` and `plane_pixel_width[ 1 + ( chroma_planes ? 2 : 0 ) ]` value is `slice_pixel_width`.
-
-If `chroma_planes` is set to 1, `plane_pixel_width[ 1 ]` and `plane_pixel_width[ 2 ]` value is `ceil( slice_pixel_width / (1 << log2_h_chroma_subsample) )`.
+(chroma\_planes == 1 && (p == 1 || p == 2)) ? ceil( slice\_pixel\_width / (1 << log2\_h\_chroma_subsample) ) : slice\_pixel\_width.
 
 ### slice\_pixel\_width
 
-`slice_pixel_width` is the width in `Pixels` of the slice.
+`slice_pixel_width` is the width in `Pixels` of the slice. It is defined as:
 
-Its value is `floor( ( slice_x + slice_width ) * slice_pixel_width / num_h_slices ) - slice_pixel_x`.
+floor( ( slice\_x + slice\_width ) \* slice\_pixel\_width / num\_h\_slices ) - slice\_pixel\_x
 
 ### slice\_pixel\_x
 
-`slice_pixel_x` is the slice horizontal position in `Pixels`.
+`slice_pixel_x` is the slice horizontal position in `Pixels`. It is defined as:
 
-Its value is `floor( slice_x * frame_pixel_width / num_h_slices )`.
+floor( slice\_x \* frame\_pixel\_width / num\_h\_slices )
 
 ### sample\_difference
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -285,7 +285,7 @@ For each `Plane` of each slice, a Quantization Table Set is selected from an ind
 - For Cb and Cr `Planes`, `quant_table_set_index[ 1 ]` index is used
 - For extra `Plane`, `quant_table_set_index[ (version <= 3 || chroma_planes) ? 2 : 1 ]` index is used
 
-Background: in first implementations of FFV1 bitstream, the index for Cb and Cr `Planes` was stored even if it is not used (chroma_planes set to 0), this index is kept for version <= 3 in order to keep compatibility with FFV1 bitstreams in the wild.
+Background: in first implementations of FFV1 bitstream, the index for Cb and Cr `Planes` was stored even if it is not used (chroma_planes set to 0), this index is kept for `version` <= 3 in order to keep compatibility with FFV1 bitstreams in the wild.
 
 ## Color spaces
 
@@ -862,18 +862,18 @@ Decoders SHOULD reject a file with version >= 3 && ConfigurationRecordIsPresent 
 
 After a version is considered stable (a micro-version value is assigned to be the first stable variant of a specific version), each new micro-version after this first stable variant is compatible with the previous micro-version: decoders SHOULD NOT reject a file due to an unknown micro-version equal or above the micro-version considered as stable.
 
-Meaning of `micro_version` for version 3:
+Meaning of `micro_version` for `version` 3:
 
 |value  | micro\_version          |
 |-------|:------------------------|
 |0...3  | reserved\*              |
 |4      | first stable variant    |
 |Other  | reserved for future use |
-Table: The definitions for `micro_version` values.
+Table: The definitions for `micro_version` values for FFV1 version 3.
 
 \* development versions may be incompatible with the stable variants.
 
-Meaning of `micro_version` for version 4 (note: at the time of writing of this specification, version 4 is not considered stable so the first stable version value is to be announced in the future):{V4}
+Meaning of `micro_version` for `version` 4 (note: at the time of writing of this specification, version 4 is not considered stable so the first stable `micro_version` value is to be announced in the future):{V4}
 
 |value   | micro\_version          |{V4}
 |--------|:------------------------|{V4}
@@ -1481,7 +1481,7 @@ QuantizationTable(i, j, scale) {                              |
 
 # Restrictions
 
-To ensure that fast multithreaded decoding is possible, starting with `version` 3 and if `frame_pixel_width * frame_pixel_height` is more than 101376, `slice_width * slice_height` MUST be less or equal to `num_h_slices * num_v_slices / 4`.
+To ensure that fast multithreaded decoding is possible, starting with version 3 and if `frame_pixel_width * frame_pixel_height` is more than 101376, `slice_width * slice_height` MUST be less or equal to `num_h_slices * num_v_slices / 4`.
 Note: 101376 is the frame size in `Pixels` of a 352x288 frame also known as CIF ("Common Intermediate Format") frame size format.
 
 For each `Frame`, each position in the slice raster MUST be filled by one and only one slice of the `Frame` (no missing slice position, no slice overlapping).
@@ -1520,7 +1520,7 @@ Optional parameters:
 
   This parameter is used to signal the capabilities of a receiver implementation. This parameter MUST NOT be used for any other purpose.
 
-  `version`:  The version of the FFV1 encoding as defined by (#version).
+  `version`:  The `version` of the FFV1 encoding as defined by (#version).
 
   `micro_version`:  The `micro_version` of the FFV1 encoding as defined by (#micro-version).
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -922,7 +922,7 @@ If `state_transition_delta` is not present in the FFV1 bitstream, all Range code
 
 Restrictions:
 
-If `colorspace_type` is 1, then `chroma_planes` MUST be 1, `log2_h_chroma_subsample` MUST be 0, and `log2_v_chroma_subsample` MUST be 0.
+Decoders SHOULD reject a content with `colorspace_type` == 1 && (`chroma_planes` != 1 || `log2_h_chroma_subsample` != 0 || `log2_v_chroma_subsample` != 0).
 
 ### chroma\_planes
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -321,26 +321,26 @@ JPEG2000-RCT is a Reversible Color Transform that codes RGB (red, green, blue) `
 SVGI:!---
 SVGI:![svg](rgb1.svg "rgb 1")
 SVGI:!---
-SVGC:rgb1.svg=$$\\\\begin{array}{ccccccc}Cb & = & b-g \\\\\\ Cr & = & r-g \\\\\\ Y & = & g+(Cb+Cr)>>2 \\\\\\ g & = & Y-(Cb+Cr)>>2 \\\\\\ r & = & Cr+g \\\\\\ b & = & Cb+g \\\\end{array}$$
-AART:Cb=b-g
-AART:Cr=r-g
-AART:Y=g+(Cb+Cr)>>2
-AART:g=Y-(Cb+Cr)>>2
-AART:r=Cr+g
-AART:b=Cb+g
+SVGC:rgb1.svg=$$\\\\begin{array}{ccccccc}Cb & = & b - g \\\\\\ Cr & = & r - g \\\\\\ Y & = & g + ( Cb + Cr)>>2 \\\\\\ g & = & Y - ( Cb + Cr ) >> 2 \\\\\\ r & = & Cr + g \\\\\\ b & = & Cb + g \\\\end{array}$$
+AART:Cb = b - g
+AART:Cr = r - g
+AART:Y = g + (Cb + Cr) >> 2
+AART:g = Y - (Cb + Cr) >> 2
+AART:r = Cr + g
+AART:b = Cb + g
 
 Exception for the JPEG2000-RCT conversion: if `bits_per_raw_sample` is between 9 and 15 inclusive and `extra_plane` is 0, the following formulae for reversible conversions between YCbCr and RGB MUST be used instead of the ones above:
 
 SVGI:!---
 SVGI:![svg](rgb2.svg "rgb 2")
 SVGI:!---
-SVGC:rgb2.svg=$$\\\\begin{array}{ccccccc}Cb & = & g-b \\\\\\ Cr & = & r-b \\\\\\ Y & = & b+(Cb+Cr)>>2 \\\\\\ b & = & Y-(Cb+Cr)>>2 \\\\\\ r & = & Cr+b \\\\\\ g & = & Cb+b \\\\end{array}$$
-AART:Cb=g-b
-AART:Cr=r-b
-AART:Y=b+(Cb+Cr)>>2
-AART:b=Y-(Cb+Cr)>>2
-AART:r=Cr+b
-AART:g=Cb+b
+SVGC:rgb2.svg=$$\\\\begin{array}{ccccccc}Cb & = & g - b \\\\\\ Cr & = & r - b \\\\\\ Y & = & b + (Cb + Cr)>>2 \\\\\\ b & = & Y - (Cb + Cr)>>2 \\\\\\ r & = & Cr + b \\\\\\ g & = & Cb + b \\\\end{array}$$
+AART:Cb = g - b
+AART:Cr = r - b
+AART:Y = b +(Cb + Cr) >> 2
+AART:b = Y -(Cb + Cr) >> 2
+AART:r = Cr + b
+AART:g = Cb + b
 
 Background: At the time of this writing, in all known implementations of FFV1 bitstream, when `bits_per_raw_sample` was between 9 and 15 inclusive and `extra_plane` is 0, GBR `Planes` were used as BGR `Planes` during both encoding and decoding. In the meanwhile, 16-bit JPEG2000-RCT was implemented without this issue in one implementation and validated by one conformance checker. Methods to address this exception for the transform are under consideration for the next version of the FFV1 bitstream.
 
@@ -373,7 +373,7 @@ SVGI:![svg](samplediff.svg "coding of the sample difference")
 SVGI:!---
 SVGC:samplediff.svg=$$coder\\\_input=[(sample\\\_difference+2^{bits-1})\\&(2^{bits}-1)]-2^{bits-1}$$
 AART:coder_input =
-AART:    [(sample_difference + 2^(bits-1)) & (2^bits - 1)] - 2^(bits-1)
+AART:    [(sample_difference + 2 ^ (bits-1)) & (2 ^ bits - 1)] - 2 ^ (bits - 1)
 
 ### Range Coding Mode
 
@@ -387,7 +387,7 @@ SVGI:!---
 SVGI:![svg](rangebinaryvalues1.svg "range binary values 1")
 SVGI:!---
 SVGC:rangebinaryvalues1.svg=$$r\_{i}=\\\\lfloor\\\\frac{R_{i}S_{i,C_{i}}}{2^{8}}\\\\rfloor$$
-AART:r_{i} = floor( ( R_{i} * S_{i,C_{i}} ) / 2^8 )
+AART:r_{i} = floor( ( R_{i} * S_{i,C_{i}} ) / 2 ^ 8 )
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues2.svg "range binary values 2")
@@ -415,15 +415,15 @@ SVGI:!---
 SVGI:![svg](rangebinaryvalues4.svg "range binary values 4")
 SVGI:!---
 SVGC:rangebinaryvalues4.svg=$$\\\\begin{array}{ccccccc} R\_{i+1}=2^{8}t\_{i} & \\\\wedge & L\_{i+1}=2^{8}l\_{i}+B\_{j\_{i}} & \\\\wedge & j\_{i+1}=j\_{i}+1 & \\\\Longleftarrow & t\_{i}<2^{8}\\\\\\ R\_{i+1}=t\_{i} & \\\\wedge & L\_{i+1}=l\_{i} & \\\\wedge & j\_{i+1}=j\_{i} & \\\\Longleftarrow & t\_{i}\\\\geq2^{8}\\\\end{array}$$
-AART:R_{i+1} =  2^8 * t_{i}                   AND
-AART:L_{i+1} =  2^8 * l_{i} + B_{j_{i}}       AND
+AART:R_{i+1} =  2 ^ 8 * t_{i}                 AND
+AART:L_{i+1} =  2 ^ 8 * l_{i} + B_{j_{i}}     AND
 AART:j_{i+1} =  j_{i} + 1                     <==
-AART:t_{i}   <  2^8
+AART:t_{i}   <  2 ^ 8
 AART:
 AART:R_{i+1} =  t_{i}                         AND
 AART:L_{i+1} =  l_{i}                         AND
 AART:j_{i+1} =  j_{i}                         <==
-AART:t_{i}   >= 2^8
+AART:t_{i}   >= 2 ^ 8
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues5.svg "range binary values 5")
@@ -435,7 +435,7 @@ SVGI:!---
 SVGI:![svg](rangebinaryvalues6.svg "range binary values 6")
 SVGI:!---
 SVGC:rangebinaryvalues6.svg=$$L_{0}=2^{8}B_{0}+B_{1}$$
-AART:L_{0} = 2^8 * B_{0} + B_{1}
+AART:L_{0} = 2 ^ 8 * B_{0} + B_{1}
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues7.svg "range binary values 7")
@@ -944,11 +944,11 @@ Decoders SHOULD accept and interpret `bits_per_raw_sample` = 0 as 8.
 
 ### log2\_h\_chroma\_subsample
 
-`log2_h_chroma_subsample` indicates the subsample factor, stored in powers to which the number 2 must be raised, between luma and chroma width (`chroma_width = 2^-log2_h_chroma_subsample^ * luma_width`).
+`log2_h_chroma_subsample` indicates the subsample factor, stored in powers to which the number 2 must be raised, between luma and chroma width (`chroma_width = 2 ^ -log2_h_chroma_subsample * luma_width`).
 
 ### log2\_v\_chroma\_subsample
 
-`log2_v_chroma_subsample` indicates the subsample factor, stored in powers to which the number 2 must be raised, between luma and chroma height (`chroma_height=2^-log2_v_chroma_subsample^ * luma_height`).
+`log2_v_chroma_subsample` indicates the subsample factor, stored in powers to which the number 2 must be raised, between luma and chroma height (`chroma_height = 2 ^ -log2_v_chroma_subsample * luma_height`).
 
 ### `extra\_plane`
 
@@ -1096,7 +1096,7 @@ FFV1 SHOULD use `V_FFV1` as the Matroska `Codec ID`. For FFV1 versions 2 or less
 
 A `Frame` is an encoded representation of a complete static image. The whole `Frame` is provided by the underlaying container.
 
-A `Frame` consists of the `keyframe` field, `Parameters` (if `version` <=1), and a sequence of independent slices. The pseudo-code below describes the contents of a `Frame`.
+A `Frame` consists of the `keyframe` field, `Parameters` (if `version` <= 1), and a sequence of independent slices. The pseudo-code below describes the contents of a `Frame`.
 
 ```c
 pseudo-code                                                   | type

--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -171,12 +171,16 @@
   <seriesInfo name="ISO" value="Standard 9899" />
 </reference>
 
-# Appendix A (informative): Multi-theaded decoder implementation suggestions
+# Multi-theaded decoder implementation suggestions
+
+This appendix is informative.
 
 The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
 
 After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
 
-# Appendix B (informative): Future handling of some streams created by non conforming encoders
+# Future handling of some streams created by non conforming encoders
+
+This appendix is informative.
 
 Some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity` in the `reserved` bits of `Slice()`. Any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` if `version` == 0 or `version` == 1. Else a decoder conforming to the revised specification could not distinguish between a revised bitstream and such buggy bitstream in the wild.

--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -170,3 +170,13 @@
   </front>
   <seriesInfo name="ISO" value="Standard 9899" />
 </reference>
+
+# Appendix A (informative): Multi-theaded decoder implementation suggestions
+
+The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
+
+After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
+
+# Appendix B (informative): Future handling of some streams created by non conforming encoders
+
+Some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity` in the `reserved` bits of `Slice()`. Any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` if `version` == 0 or `version` == 1. Else a decoder conforming to the revised specification could not distinguish between a revised bitstream and such buggy bitstream in the wild.


### PR DESCRIPTION
This pull request builds upon https://github.com/FFmpeg/FFV1/pull/199 and responds to the following comment at https://mailarchive.ietf.org/arch/msg/cellar/K1girgkVr4AKNDzPcUPyRjla7Rc/:

> Section 9:
> * Appendices go after the references.