### PR TITLE
More ad review updates take 2

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -922,7 +922,7 @@ If `state_transition_delta` is not present in the FFV1 bitstream, all Range code
 
 Restrictions:
 
-If `colorspace_type` is 1, then `chroma_planes` MUST be 1, `log2_h_chroma_subsample` MUST be 0, and `log2_v_chroma_subsample` MUST be 0.
+Decoders SHOULD reject FFV1 bitstreams with `colorspace_type` == 1 && (`chroma_planes` != 1 || `log2_h_chroma_subsample` != 0 || `log2_v_chroma_subsample` != 0).
 
 ### chroma\_planes
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1172,8 +1172,6 @@ Encoders SHOULD NOT fill these bits.
 
 Decoders SHOULD ignore these bits.
 
-Note in case these bits are used in a later revision of this specification: any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` for `version` 0 and 1 of the bitstream. Background: Due to some non-conforming encoders, some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity`. As a result, a decoder conforming to the revised specification could not distinguish between a revised bitstream and a buggy bitstream.
-
 ## Slice Header
 
 A `Slice Header` provides information about the decoding configuration of the `Slice`, such as its spatial position, size, and aspect ratio. The pseudo-code below describes the contents of the `Slice Header`.

--- a/ffv1.md
+++ b/ffv1.md
@@ -857,7 +857,7 @@ Decoders SHOULD reject FFV1 bitstreams with version >= 3 && ConfigurationRecordI
 |4       |  FFV1 version 4         |{V4}
 |Other   |  reserved for future use|
 
-\* Version 2 was never enabled in the encoder thus version 2 files SHOULD NOT exist, and this document does not describe them to keep the text simpler.
+\* Version 2 was never enabled in any encoder known to the authors of this document. Decoders SHOULD reject FFV1 bitstreams with `version` == 2.
 
 ### micro\_version
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1575,12 +1575,6 @@ The IANA is requested to register the following values:
 
    - Media type registration as described in (#media-type-definition).
 
-# Appendix A: Multi-theaded decoder implementation suggestions
-
-The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
-
-After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
-
 # Changelog
 
 See <https://github.com/FFmpeg/FFV1/commits/master>

--- a/ffv1.md
+++ b/ffv1.md
@@ -842,11 +842,11 @@ CONTEXT_SIZE is 32.
 
 `version` specifies the version of the FFV1 bitstream.
 
-Each version is incompatible with other versions: decoders SHOULD reject a file due to an unknown version.
+Each version is incompatible with other versions: decoders SHOULD reject FFV1 bitstreams due to an unknown version.
 
-Decoders SHOULD reject a file with version <= 1 && ConfigurationRecordIsPresent == 1.
+Decoders SHOULD reject FFV1 bitstreams with version <= 1 && ConfigurationRecordIsPresent == 1.
 
-Decoders SHOULD reject a file with version >= 3 && ConfigurationRecordIsPresent == 0.
+Decoders SHOULD reject FFV1 bitstreams with version >= 3 && ConfigurationRecordIsPresent == 0.
 
 |value   | version                 |
 |:-------|:------------------------|
@@ -863,7 +863,7 @@ Decoders SHOULD reject a file with version >= 3 && ConfigurationRecordIsPresent 
 
 `micro_version` specifies the micro-version of the FFV1 bitstream.
 
-After a version is considered stable (a micro-version value is assigned to be the first stable variant of a specific version), each new micro-version after this first stable variant is compatible with the previous micro-version: decoders SHOULD NOT reject a file due to an unknown micro-version equal or above the micro-version considered as stable.
+After a version is considered stable (a micro-version value is assigned to be the first stable variant of a specific version), each new micro-version after this first stable variant is compatible with the previous micro-version: decoders SHOULD NOT reject FFV1 bitstreams due to an unknown micro-version equal or above the micro-version considered as stable.
 
 Meaning of `micro_version` for `version` 3:
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -1223,7 +1223,9 @@ Inferred to be 1 if not present.
 
 ### quant\_table\_set\_index\_count
 
-`quant_table_set_index_count` is defined as `1 + ( ( chroma_planes || version <= 3 ) ? 1 : 0 ) + ( `extra_plane` ? 1 : 0 )`.
+`quant_table_set_index_count` is defined as:
+
+1 + ( ( chroma\_planes || version <= 3 ) ? 1 : 0 ) + ( extra\_plane ? 1 : 0 )
 
 ### quant\_table\_set\_index
 
@@ -1315,27 +1317,27 @@ SliceContent( ) {                                             |
 
 ### primary\_color\_count
 
-`primary_color_count` is defined as `1 + ( chroma_planes ? 2 : 0 ) + ( extra_plane ? 1 : 0 )`.
+`primary_color_count` is defined as:
+
+1 + ( chroma\_planes ? 2 : 0 ) + ( extra\_plane ? 1 : 0 )
 
 ### plane\_pixel\_height
 
-`plane_pixel_height[ p ]` is the height in pixels of plane p of the slice.
+`plane_pixel_height[ p ]` is the height in `Pixels` of `Plane` p of the `Slice`. It is defined as:
 
-`plane_pixel_height[ 0 ]` and `plane_pixel_height[ 1 + ( chroma_planes ? 2 : 0 ) ]` value is `slice_pixel_height`.
-
-If `chroma_planes` is set to 1, `plane_pixel_height[ 1 ]` and `plane_pixel_height[ 2 ]` value is `ceil( slice_pixel_height / (1 << log2_v_chroma_subsample) )`.
+(chroma\_planes == 1 && (p == 1 || p == 2)) ? ceil(slice\_pixel\_height / (1 << log2\_v\_chroma\_subsample)) : slice\_pixel\_height
 
 ### slice\_pixel\_height
 
-`slice_pixel_height` is the height in pixels of the slice.
+`slice_pixel_height` is the height in pixels of the slice. It is defined as:
 
-Its value is `floor( ( slice_y + slice_height ) * slice_pixel_height / num_v_slices ) - slice_pixel_y`.
+floor( ( slice\_y + slice\_height ) \* slice\_pixel\_height / num\_v\_slices ) - slice\_pixel\_y.
 
 ### slice\_pixel\_y
 
-`slice_pixel_y` is the slice vertical position in pixels.
+`slice_pixel_y` is the slice vertical position in pixels. It is defined as:
 
-Its value is `floor( slice_y * frame_pixel_height / num_v_slices )`.
+floor( slice_y \* frame\_pixel\_height / num\_v\_slices )
 
 ## Line
 
@@ -1359,23 +1361,21 @@ Line( p, y ) {                                                |
 
 ### plane\_pixel\_width
 
-`plane_pixel_width[ p ]` is the width in `Pixels` of `Plane` p of the slice.
+`plane_pixel_width[ p ]` is the width in `Pixels` of `Plane` p of the `Slice`. It is defined as:
 
-`plane_pixel_width[ 0 ]` and `plane_pixel_width[ 1 + ( chroma_planes ? 2 : 0 ) ]` value is `slice_pixel_width`.
-
-If `chroma_planes` is set to 1, `plane_pixel_width[ 1 ]` and `plane_pixel_width[ 2 ]` value is `ceil( slice_pixel_width / (1 << log2_h_chroma_subsample) )`.
+(chroma\_planes == 1 && (p == 1 || p == 2)) ? ceil( slice\_pixel\_width / (1 << log2\_h\_chroma_subsample) ) : slice\_pixel\_width.
 
 ### slice\_pixel\_width
 
-`slice_pixel_width` is the width in `Pixels` of the slice.
+`slice_pixel_width` is the width in `Pixels` of the slice. It is defined as:
 
-Its value is `floor( ( slice_x + slice_width ) * slice_pixel_width / num_h_slices ) - slice_pixel_x`.
+floor( ( slice\_x + slice\_width ) \* slice\_pixel\_width / num\_h\_slices ) - slice\_pixel\_x
 
 ### slice\_pixel\_x
 
-`slice_pixel_x` is the slice horizontal position in `Pixels`.
+`slice_pixel_x` is the slice horizontal position in `Pixels`. It is defined as:
 
-Its value is `floor( slice_x * frame_pixel_width / num_h_slices )`.
+floor( slice\_x \* frame\_pixel\_width / num\_h\_slices )
 
 ### sample\_difference
 

--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -173,10 +173,14 @@
 
 # Multi-theaded decoder implementation suggestions
 
+This appendix is informative.
+
 The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
 
 After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
 
 # Future handling of some streams created by non conforming encoders
+
+This appendix is informative.
 
 Some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity` in the `reserved` bits of `Slice()`. Any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` if `version` == 0 or `version` == 1. Else a decoder conforming to the revised specification could not distinguish between a revised bitstream and such buggy bitstream in the wild.

--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -170,3 +170,9 @@
   </front>
   <seriesInfo name="ISO" value="Standard 9899" />
 </reference>
+
+# Multi-theaded decoder implementation suggestions
+
+The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
+
+After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.

--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -176,3 +176,7 @@
 The FFV1 bitstream is parsable in two ways: in sequential order as described in this document or with the pre-analysis of the footer of each slice. Each slice footer contains a `slice_size` field so the boundary of each slice is computable without having to parse the slice content. That allows multi-threading as well as independence of slice content (a bitstream error in a slice header or slice content has no impact on the decoding of the other slices).
 
 After having checked `keyframe` field, a decoder SHOULD parse `slice_size` fields, from `slice_size` of the last slice at the end of the `Frame` up to `slice_size` of the first slice at the beginning of the `Frame`, before parsing slices, in order to have slices boundaries. A decoder MAY fallback on sequential order e.g. in case of a corrupted `Frame` (frame size unknown, `slice_size` of slices not coherent...) or if there is no possibility of seeking into the stream.
+
+# Future handling of some streams created by non conforming encoders
+
+Some bitstreams were found with 40 extra bits corresponding to `error_status` and `slice_crc_parity` in the `reserved` bits of `Slice()`. Any revision of this specification SHOULD care about avoiding to add 40 bits of content after `SliceContent` if `version` == 0 or `version` == 1. Else a decoder conforming to the revised specification could not distinguish between a revised bitstream and such buggy bitstream in the wild.


### PR DESCRIPTION
This PR is intended to supersede both https://github.com/FFmpeg/FFV1/pull/199 and https://github.com/FFmpeg/FFV1/pull/200. It makes the commits about appendices handling easier to follow.

I agreed with @michaelni's [comment](https://github.com/FFmpeg/FFV1/pull/199#issuecomment-624910280) and used the term "FFV1 bitstream" rather than "a content", though the comment there about the colorspace restriction may still need work. The comment there about line-length is the same before and after the PR (It's about some pseudo-code table being too long), so I can adjust that in a subsequent ping.

Pinging @JeromeMartinez to review as well since this edits his work.