### PR TITLE
Remove duplicated and vague 2nd CRC documentation

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -1063,7 +1063,7 @@ Decoders conforming to this version of this specification SHALL ignore its value
 
 This is equivalent to storing the CRC remainder in the 32-bit parity.
 
-The CRC generator polynomial used is the standard IEEE CRC polynomial (0x104C11DB7) with initial value 0.
+The CRC generator polynomial used is described in (#slice-crc-parity).
 
 ### Mapping FFV1 into Containers
 


### PR DESCRIPTION
As caught by @michaelni in https://github.com/FFmpeg/FFV1/pull/181/commits/2153a62ec655f84133d678a9e13104c28b608b9d, there are 2 descriptions of the same CRC generator polynomial used.

I suggest this wording, in a dedicated PR (outside from v4 proposed changed) and with a link to the related section.