### PR TITLE
keep equation within line length constraints

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -374,8 +374,8 @@ SVGI:!---
 SVGI:![svg](samplediff.svg "coding of the sample difference")
 SVGI:!---
 SVGC:samplediff.svg=$$coder\\\_input=[(sample\\\_difference+2^{bits-1})\\&(2^{bits}-1)]-2^{bits-1}$$
-AART:coder_input =
-AART:    [(sample_difference + 2 ^ (bits-1)) & (2 ^ bits - 1)] - 2 ^ (bits - 1)
+AART:coder_input = [(sample_difference + 2 ^ (bits - 1)) &
+AART:              (2 ^ bits - 1)] - 2 ^ (bits - 1)
 
 ### Range Coding Mode
 


### PR DESCRIPTION
After @JeromeMartinez 's commit at https://github.com/FFmpeg/FFV1/commit/9228942500e6bc92943757b3a975255de7a72465 there is an idnit error as the line length exceeds 72 characters in the rendered txt output. This is an attempt to get the output back to <=72.