### PR TITLE
QuantizationTableSet place

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -818,7 +818,7 @@ QuantizationTable(i, j, scale) {                              |
     v = 0                                                     |
     for (k = 0; k < 128;) {                                   |
         len - 1                                               | ur
-        for (a = 0; a < len; a++) {                           |
+        for (n = 0; n < len; n++) {                           |
             quant_tables[ i ][ j ][ k ] = scale * v           |
             k++                                               |
         }                                                     |


### PR DESCRIPTION
More AD review updates, it is preferred to define `QuantizationTableSet` before using it, so I move the corresponding section (no change in the section itself).

I didn't inverted `QuantizationTableSet` and `QuantizationTable` because the remark was focused on `QuantizationTableSet` being a lot later than when it is used.