### PR TITLE
add missing required value attribute for a seriesInfo in range-coding reference

### DIFF
--- a/rfc_backmatter.md
+++ b/rfc_backmatter.md
@@ -59,7 +59,7 @@
     <author initials="N." surname="Martin" fullname=""/>
     <date month="July" year="1979" />
   </front>
-  <seriesInfo name="Proc. Institution of Electronic and Radio Engineers International Conference on Video and Data Recording" value="" />
+  <seriesInfo name="Proceedings of the Conference on Video and Data Recording." value="Institution of Electronic and Radio Engineers, Hampshire, England"/>
 </reference>
 
 <reference anchor="AVI" target="https://msdn.microsoft.com/en-us/library/windows/desktop/dd318189%28v=vs.85%29.aspx">


### PR DESCRIPTION
This PR is a subset of what is attempted in https://github.com/FFmpeg/FFV1/pull/219 in order to fix the make process which breaks in mmark 2.2.8 or higher (which corrects handling of seriesInfo values in the references section).

Before the PR:

```
% mmark -version
2.2.8

% make
RFC rendering has been tested with mmark version 2.0.48, xml2rfc 2.32.0, xmlstarlet 1.6.1, pdfcrop v1.38, and pdf2svg 0.2.3, please ensure these are installed and recent enough.
bash makesvg
cat rfc_frontmatter.md "ffv1.md" rfc_backmatter.md | grep -v "^AART:" | grep -v "^SVGC" | grep -v "{V4}" |  sed "s|^AART:||g;s|{V3}||g;s|SVGI:||g" > merged_rfchtml.md
mmark merged_rfchtml.md | sed 's|<date year="undated"></date>|<date>undated</date>|g' > draft-ietf-cellar-ffv1-16.xml
bash svg2src draft-ietf-cellar-ffv1-16.xml
xml2rfc --html --v3 "draft-ietf-cellar-ffv1-16.xml" -o "draft-ietf-cellar-ffv1-16.html"
draft-ietf-cellar-ffv1-16.xml(1912): Error: Element seriesInfo failed to validate attributes, at /rfc/back/references[2]/reference[7]/seriesInfo
/Users/davidrice/github/FFV1/draft-ietf-cellar-ffv1-16.xml(3): Error: Invalid document before running preptool.
Unable to complete processing draft-ietf-cellar-ffv1-16.xml
make: *** [draft-ietf-cellar-ffv1-16.html] Error 1
```

after the PR:
```
% mmark -version
2.2.8

% make
RFC rendering has been tested with mmark version 2.0.48, xml2rfc 2.32.0, xmlstarlet 1.6.1, pdfcrop v1.38, and pdf2svg 0.2.3, please ensure these are installed and recent enough.
bash makesvg
cat rfc_frontmatter.md "ffv1.md" rfc_backmatter.md | grep -v "^AART:" | grep -v "^SVGC" | grep -v "{V4}" |  sed "s|^AART:||g;s|{V3}||g;s|SVGI:||g" > merged_rfchtml.md
mmark merged_rfchtml.md | sed 's|<date year="undated"></date>|<date>undated</date>|g' > draft-ietf-cellar-ffv1-16.xml
bash svg2src draft-ietf-cellar-ffv1-16.xml
xml2rfc --html --v3 "draft-ietf-cellar-ffv1-16.xml" -o "draft-ietf-cellar-ffv1-16.html"
 Created file draft-ietf-cellar-ffv1-16.html
bash makesvg
cat rfc_frontmatter.md "ffv1.md" rfc_backmatter.md | grep -v "^AART:" | grep -v "^SVGC" | grep -v "{V3}" |  sed "s|^AART:||g;s|{V4}||g;s|SVGI:||g" > merged_rfchtml-v4.md
mmark merged_rfchtml-v4.md | sed 's|<date year="undated"></date>|<date>undated</date>|g' > draft-ietf-cellar-ffv1-v4-13.xml
bash svg2src draft-ietf-cellar-ffv1-v4-13.xml
xml2rfc --html --v3 "draft-ietf-cellar-ffv1-v4-13.xml" -o "draft-ietf-cellar-ffv1-v4-13.html"
 Created file draft-ietf-cellar-ffv1-v4-13.html
xml2rfc --v3 "draft-ietf-cellar-ffv1-16.xml" -o "draft-ietf-cellar-ffv1-16.txt"
 Created file draft-ietf-cellar-ffv1-16.txt
xml2rfc --v3 "draft-ietf-cellar-ffv1-v4-13.xml" -o "draft-ietf-cellar-ffv1-v4-13.txt"
 Created file draft-ietf-cellar-ffv1-v4-13.txt
```

[Section 2.47.6 of RFC7991](https://tools.ietf.org/html/rfc7991#section-2.47.6) mandates that seriesInfo/@value attribute, but it is currently missing. This PR attempts to fix it while circumventing the standing issues of https://github.com/FFmpeg/FFV1/pull/219 so we can have a valid RFC7991 xml and fix the make process under the current mmark release. If this PR is approved and merged, I can rebase https://github.com/FFmpeg/FFV1/pull/219.