### PR TITLE
Typos and clarity

### DIFF
--- a/ffv1.md
+++ b/ffv1.md
@@ -437,6 +437,18 @@ C~i~
 B~i~
 : the i-th byte of the bytestream.
 
+R~i~
+: the Range at the i-th symbol.
+
+r~i~
+: the boundary between two sub-ranges of R~i~: a sub-range of r~i~ values and a sub-range R~i~ - r~i~ values.
+
+L~i~
+: the Low value of the Range at the i-th symbol.
+
+t~i~
+: a temporary variable to transmit sub-ranges between range coding operations.
+
 b~i~
 : the i-th Range coded binary value.
 

--- a/ffv1.md
+++ b/ffv1.md
@@ -447,26 +447,28 @@ S~0,\ i~
 j_(n)
 : the length of the bytestream encoding n binary symbols.
 
+The following Range coder state variables are initialized to the following values. The Range is initialized to a value of 65,280 (expressed in base 16 as 0xFF00) as depicted in [@figureInitializeRange]. The Low is initialized according to the value of the first two bytes as depicted in [@figureInitializeLow]. j~i~ tracks the length of the bytestream encoding while incremening from an initial value of j~0~ to a final value of j~n~. j~0~ is initialized to 2 as depicted in [@figureInitializeLength].
+
 SVGI:!---
 SVGI:![svg](rangebinaryvalues5.svg "range binary values 5")
 SVGI:!---
 SVGC:rangebinaryvalues5.svg=$$R_{0}=65280$$
 AART:R_(0) = 65280
-Figure: The initial value for "Range".
+Figure: The initial value for "Range". {#figureInitializeRange}
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues6.svg "range binary values 6")
 SVGI:!---
 SVGC:rangebinaryvalues6.svg=$$L_{0}=2^{8}B_{0}+B_{1}$$
 AART:L_(0) = 2 ^ 8 * B_(0) + B_(1)
-Figure: The initial value for "Low" is set according to the first two bytes of the bytestream.
+Figure: The initial value for "Low" is set according to the first two bytes of the bytestream. {#figureInitializeLow}
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues7.svg "range binary values 7")
 SVGI:!---
 SVGC:rangebinaryvalues7.svg=$$j_{0}=2$$
 AART:j_(0) = 2
-Figure: The initial value for "j", the length of the bytestream encoding.
+Figure: The initial value for "j", the length of the bytestream encoding. {#figureInitializeLength}
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues1.svg "range binary values 1")

--- a/ffv1.md
+++ b/ffv1.md
@@ -444,7 +444,7 @@ b~i~
 S~0,\ i~
 : the i-th initial state.
 
-j_(n)
+j~n~
 : the length of the bytestream encoding n binary symbols.
 
 The following Range coder state variables are initialized to the following values. The Range is initialized to a value of 65,280 (expressed in base 16 as 0xFF00) as depicted in [@figureInitializeRange]. The Low is initialized according to the value of the first two bytes as depicted in [@figureInitializeLow]. j~i~ tracks the length of the bytestream encoding while incremening from an initial value of j~0~ to a final value of j~n~. j~0~ is initialized to 2 as depicted in [@figureInitializeLength].

--- a/ffv1.md
+++ b/ffv1.md
@@ -429,7 +429,9 @@ Early experimental versions of FFV1 used the CABAC Arithmetic coder from H.264 a
 
 #### Range Binary Values
 
-To encode binary digits efficiently a Range coder is used.
+To encode binary digits efficiently a Range coder is used. A Range coder encodes a series of binary symbols by using a probability estimation within each context. The sizes of each of the 2 sub-ranges are proportional to their estimated probability. The quantization table is used to choose the context used from the surrounding image sample values for the case of coding the sample differences. Coding integers is done by coding multiple binary values. The range decoder will read bytes until it can determine which sub-range the input falls into to return the next binary symbol.
+
+To describe Range coding for FFV1 the following values are used:
 
 C~i~
 : the i-th Context.

--- a/ffv1.md
+++ b/ffv1.md
@@ -146,9 +146,9 @@ Note: the operators and the order of precedence are the same as used in the C pr
 
 `median(a,b,c)`         means the numerical middle value in a data set of a, b, and c, i.e. a+b+c-min(a,b,c)-max(a,b,c).
 
-`A <== B`               means B implies A.
+`A ==> B`               means A implies B.
 
-`A <==> B`              means A <== B , B <== A.
+`A <==> B`              means A ==> B , B ==> A.
 
 a~b~                    means the b-th value of a sequence of a
 
@@ -480,39 +480,39 @@ Figure: A formula of the read of a binary value in Range Binary mode. {#figureGe
 SVGI:!---
 SVGI:![svg](rangebinaryvalues2.svg "range binary values 2")
 SVGI:!---
-SVGC:rangebinaryvalues2.svg=$$\\\\begin{array}{ccccccccc} S_{i+1,C_{i}}=zero\\_state_{S_{i,C_{i}}} & \\\\wedge & l_{i}=L_{i} & \\\\wedge & t_{i}=R_{i}-r_{i} & \\\\Longleftarrow & b_{i}=0 & \\\\Longleftrightarrow & L_{i}<R_{i}-r_{i} \\\\\\ S_{i+1,C_{i}}=one\\_state_{S_{i,C_{i}}} & \\\\wedge & l_{i}=L_{i}-R_{i}+r_{i} & \\\\wedge & t_{i}=r_{i} & \\\\Longleftarrow & b_{i}=1 & \\\\Longleftrightarrow & L_{i}\\\\geq R_{i}-r_{i} \\\\end{array}$$
+SVGC:rangebinaryvalues2.svg=$$\\\\begin{array}{ccccccccc} b_{i}=0 & \\\\Longleftrightarrow & L_{i}<R_{i}-r_{i} & \\\\Longrightarrow & S_{i+1,C_{i}}=zero\\_state_{S_{i,C_{i}}} & \\\\wedge & l_{i}=L_{i} & \\\\wedge & t_{i}=R_{i}-r_{i} \\\\\\ b_{i}=1 & \\\\Longleftrightarrow & L_{i}\\\\geq R_{i}-r_{i} & \\\\Longrightarrow & S_{i+1,C_{i}}=one\\_state_{S_{i,C_{i}}} & \\\\wedge & l_{i}=L_{i}-R_{i}+r_{i} & \\\\wedge & t_{i}=r_{i} \\\\end{array}$$
+AART:           b_(i) =  0                          <==>
+AART:           L_(i) <  R_(i) - r_(i)              ==>
 AART:S_(i + 1, C_(i)) =  zero_state_(S_(i, C_(i)))  AND
 AART:           l_(i) =  L_(i)                      AND
-AART:           t_(i) =  R_(i) - r_(i)              <==
-AART:           b_(i) =  0                          <==>
-AART:           L_(i) <  R_(i) - r_(i)
+AART:           t_(i) =  R_(i) - r_(i)
 AART:
+AART:           b_(i) =  1                          <==>
+AART:           L_(i) >= R_(i) - r_(i)              ==>
 AART:S_(i + 1, C_(i)) =  one_state_(S_(i, C_(i)))   AND
 AART:           l_(i) =  L_(i) - R_(i) + r_(i)      AND
-AART:           t_(i) =  r_(i)                      <==
-AART:           b_(i) =  1                          <==>
-AART:           L_(i) >= R_(i) - r_(i)
+AART:           t_(i) =  r_(i)
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues3.svg "range binary values 3")
 SVGI:!---
-SVGC:rangebinaryvalues3.svg=$$\\\\begin{array}{ccc}S_{i+1,k}=S_{i,k} & \\\\Longleftarrow & C_{i} \\\\neq k\\\\end{array}$$
-AART:S_(i + 1, k) = S_(i, k) <== C_(i) != k
+SVGC:rangebinaryvalues3.svg=$$\\\\begin{array}{ccc}C_{i} \\\\neq k & \\\\Longrightarrow & S_{i+1,k}=S_{i,k}\\\\end{array}$$
+AART:C_(i) != k ==> S_(i + 1, k) = S_(i, k)
 Figure: The "i+1,k"-th State is equal to the "i,k"-th State if the value of "k" is unequal to the i-th value of Context.
 
 SVGI:!---
 SVGI:![svg](rangebinaryvalues4.svg "range binary values 4")
 SVGI:!---
-SVGC:rangebinaryvalues4.svg=$$\\\\begin{array}{ccccccc} R_{i+1}=2^{8}t_{i} & \\\\wedge & L_{i+1}=2^{8}l_{i}+B_{j_{i}} & \\\\wedge & j_{i+1}=j_{i}+1 & \\\\Longleftarrow & t_{i}<2^{8}\\\\\\ R_{i+1}=t_{i} & \\\\wedge & L_{i+1}=l_{i} & \\\\wedge & j_{i+1}=j_{i} & \\\\Longleftarrow & t_{i}\\\\geq2^{8}\\\\end{array}$$
+SVGC:rangebinaryvalues4.svg=$$\\\\begin{array}{ccccccc} t_{i}<2^{8} & \\\\Longrightarrow & R_{i+1}=2^{8}t_{i} & \\\\wedge & L_{i+1}=2^{8}l_{i}+B_{j_{i}} & \\\\wedge & j_{i+1}=j_{i}+1\\\\\\ t_{i}\\\\geq2^{8} & \\\\Longrightarrow & R_{i+1}=t_{i} & \\\\wedge & L_{i+1}=l_{i} & \\\\wedge & j_{i+1}=j_{i}\\\\end{array}$$
+AART:t_(i)     <  2 ^ 8                             ==>
 AART:R_(i + 1) =  2 ^ 8 * t_(i)                     AND
 AART:L_(i + 1) =  2 ^ 8 * l_(i) + B_(j_(i))         AND
-AART:j_(i + 1) =  j_(i) + 1                         <==
-AART:t_(i)     <  2 ^ 8
+AART:j_(i + 1) =  j_(i) + 1
 AART:
+AART:t_(i)     >= 2 ^ 8                             ==>
 AART:R_(i + 1) =  t_(i)                             AND
 AART:L_(i + 1) =  l_(i)                             AND
-AART:j_(i + 1) =  j_(i)                             <==
-AART:t_(i)     >= 2 ^ 8
+AART:j_(i + 1) =  j_(i)
 Figure: The "i+1"-th values for "Range", "Low", and the length of the bytestream encoding are conditionally set depending on the "i-th" value of "t".
 
 ```c

--- a/ffv1.md
+++ b/ffv1.md
@@ -895,7 +895,7 @@ Note, this is different from JPEG-LS, which doesn’t use prediction in run mode
 
 #### Initial Values for the VLC context state
 
-When `keyframe` (see (#frame)) value is 1, all coder state variables are set to their initial state.
+When `keyframe` (see (#frame)) value is 1, all VLC coder state variables are set to their initial state.
 
 ```c
     drift     = 0;

--- a/ffv1.md
+++ b/ffv1.md
@@ -448,6 +448,27 @@ j_(n)
 : the length of the bytestream encoding n binary symbols.
 
 SVGI:!---
+SVGI:![svg](rangebinaryvalues5.svg "range binary values 5")
+SVGI:!---
+SVGC:rangebinaryvalues5.svg=$$R_{0}=65280$$
+AART:R_(0) = 65280
+Figure: The initial value for "Range".
+
+SVGI:!---
+SVGI:![svg](rangebinaryvalues6.svg "range binary values 6")
+SVGI:!---
+SVGC:rangebinaryvalues6.svg=$$L_{0}=2^{8}B_{0}+B_{1}$$
+AART:L_(0) = 2 ^ 8 * B_(0) + B_(1)
+Figure: The initial value for "Low" is set according to the first two bytes of the bytestream.
+
+SVGI:!---
+SVGI:![svg](rangebinaryvalues7.svg "range binary values 7")
+SVGI:!---
+SVGC:rangebinaryvalues7.svg=$$j_{0}=2$$
+AART:j_(0) = 2
+Figure: The initial value for "j", the length of the bytestream encoding.
+
+SVGI:!---
 SVGI:![svg](rangebinaryvalues1.svg "range binary values 1")
 SVGI:!---
 SVGC:rangebinaryvalues1.svg=$$r_{i}=\\\\lfloor\\\\frac{R_{i}S_{i,C_{i}}}{2^{8}}\\\\rfloor$$
@@ -491,27 +512,6 @@ AART:L_(i + 1) =  l_(i)                             AND
 AART:j_(i + 1) =  j_(i)                             <==
 AART:t_(i)     >= 2 ^ 8
 Figure: The "i+1"-th values for "Range", "Low", and the length of the bytestream encoding are conditionally set depending on the "i-th" value of "t".
-
-SVGI:!---
-SVGI:![svg](rangebinaryvalues5.svg "range binary values 5")
-SVGI:!---
-SVGC:rangebinaryvalues5.svg=$$R_{0}=65280$$
-AART:R_(0) = 65280
-Figure: The initial value for "Range".
-
-SVGI:!---
-SVGI:![svg](rangebinaryvalues6.svg "range binary values 6")
-SVGI:!---
-SVGC:rangebinaryvalues6.svg=$$L_{0}=2^{8}B_{0}+B_{1}$$
-AART:L_(0) = 2 ^ 8 * B_(0) + B_(1)
-Figure: The initial value for "Low" is set according to the first two bytes of the bytestream.
-
-SVGI:!---
-SVGI:![svg](rangebinaryvalues7.svg "range binary values 7")
-SVGI:!---
-SVGC:rangebinaryvalues7.svg=$$j_{0}=2$$
-AART:j_(0) = 2
-Figure: The initial value for "j", the length of the bytestream encoding.
 
 ```c
     range = 0xFF00;

--- a/ffv1.md
+++ b/ffv1.md
@@ -431,7 +431,6 @@ Early experimental versions of FFV1 used the CABAC Arithmetic coder from H.264 a
 
 To encode binary digits efficiently a Range coder is used.
 
-{spacing="compact"}
 C~i~
 : the i-th Context.
 


### PR DESCRIPTION
Hi @michaelni, please review carefully and critically. Many of these commits are trivial but some rely on the current state of my understanding for how range coding works within FFV1 encodings. I'd like to do a little more work on this after this PR, but want to submit it at this point to ensure that my understanding of your work is correct and/or well-expressed.

This PR builds upon the discussions within https://github.com/FFmpeg/FFV1/issues/258 and https://github.com/FFmpeg/FFV1/issues/231.

Note that the PR changes many of the LaTeX formula, while https://github.com/FFmpeg/FFV1/issues/240 is still open, so please run `rm -v *.svg` before `make`.