### PR TITLE
bump to ffv1 v4 18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION := 20
 STATUS := draft-
 OUTPUT := $(STATUS)ietf-cellar-ffv1-$(VERSION)
 
-VERSION-v4 := 17
+VERSION-v4 := 18
 STATUS-v4 := draft-
 OUTPUT-v4 := $(STATUS-v4)ietf-cellar-ffv1-v4-$(VERSION-v4)
 

--- a/rfc_frontmatter.md
+++ b/rfc_frontmatter.md
@@ -14,7 +14,7 @@ stream = "IETF"
 status = "informational"{V3}
 status = "standard"{V4}
 value = "draft-ietf-cellar-ffv1-20"{V3}
-value = "draft-ietf-cellar-ffv1-v4-17"{V4}
+value = "draft-ietf-cellar-ffv1-v4-18"{V4}
 
 [[author]]
 initials="M."


### PR DESCRIPTION
As requested in the cellar working group meeting. The version of ffv1-v4 needs a bump as the current document is about to expire.